### PR TITLE
[do not merge WIP] Porting dft_tools/unstable to cpp2py+triqs/unstable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ enable_testing()
 
 # Load TRIQS, including all predefined variables from TRIQS installation
 find_package(TRIQS REQUIRED)
+find_package(Cpp2Py REQUIRED)
 
 # Check that versions are compatible
 if(NOT DFT_TOOLS_VERSION EQUAL TRIQS_VERSION)
@@ -23,13 +24,14 @@ if (NOT ${TRIQS_WITH_PYTHON_SUPPORT})
 endif()
 
 # Get hash
-triqs_get_git_hash(${CMAKE_SOURCE_DIR} "DFT_TOOLS")
-if(${GIT_RESULT} EQUAL 0)
-  message(STATUS "Hash: ${DFT_TOOLS_GIT_HASH}")
-endif(${GIT_RESULT} EQUAL 0)
+triqs_get_git_hash_of_source_dir(DFT_TOOLS_GIT_HASH)
+message(STATUS "Git hash: ${DFT_TOOLS_GIT_HASH}")
 
 # We want to be installed in the TRIQS tree
 set(CMAKE_INSTALL_PREFIX ${TRIQS_PATH})
+
+# The std for all targets
+add_compile_options(-std=c++1z)
 
 add_subdirectory(fortran/dmftproj) 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,6 @@ message(STATUS "Git hash: ${DFT_TOOLS_GIT_HASH}")
 # We want to be installed in the TRIQS tree
 set(CMAKE_INSTALL_PREFIX ${TRIQS_PATH})
 
-# The std for all targets
-add_compile_options(-std=c++1z)
-
 add_subdirectory(fortran/dmftproj) 
 
 # Add the compiling options (-D... ) for C++

--- a/c++/CMakeLists.txt
+++ b/c++/CMakeLists.txt
@@ -1,1 +1,5 @@
+
+# The std for all targets
+add_compile_options(-std=c++1z)
+
 add_subdirectory(plovasp/atm)

--- a/c++/plovasp/atm/CMakeLists.txt
+++ b/c++/plovasp/atm/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_library(atm_c dos_tetra3d.hpp dos_tetra3d.cpp argsort.hpp argsort.cpp)
 set_target_properties(atm_c PROPERTIES LINKER_LANGUAGE CXX)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/c++/plovasp/atm ${TRIQS_INCLUDE_ALL})
+target_link_libraries(atm_c triqs)
 
 install(TARGETS atm_c DESTINATION lib)
 

--- a/c++/plovasp/atm/test/CMakeLists.txt
+++ b/c++/plovasp/atm/test/CMakeLists.txt
@@ -1,24 +1,14 @@
-find_package(TriqsTest)
-enable_testing()
-
-# Linking and include info
-#add_library(atm_c dos_tetra3d.hpp dos_tetra3d.cpp argsort.h argsort.c)
-#set_target_properties(atm_c PROPERTIES LINKER_LANGUAGE CXX)
-#include_directories(${CMAKE_CURRENT_SOURCE_DIR}/c++/plovasp/atm ${TRIQS_INCLUDE_ALL})
 
 FILE(GLOB TestList RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 FOREACH( TestName1  ${TestList} )
  STRING(REPLACE ".cpp" "" TestName ${TestName1})
  add_executable( ${TestName}  ${CMAKE_CURRENT_SOURCE_DIR}/${TestName}.cpp )
  target_link_libraries( ${TestName} atm_c ${TRIQS_LIBRARY_ALL} )
- triqs_set_rpath_for_target( ${TestName} )
- triqs_add_cpp_test( ${TestName} )
+
+ add_test(NAME ${TestName} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${TestName})
+
  if (TESTS_C_WITH_VALGRIND)
   add_test ( ${TestName}_valgrind valgrind --error-exitcode=1 ${CMAKE_CURRENT_BINARY_DIR}/${TestName})
  endif()
+
 ENDFOREACH( TestName1  ${TestList} )
-
-#add_executable(test_atm test2py.cpp)
-#target_link_libraries(test_atm atm_c)
-
-#add_subdirectory(test)

--- a/fortran/dmftproj/CMakeLists.txt
+++ b/fortran/dmftproj/CMakeLists.txt
@@ -6,7 +6,35 @@ set(SOURCES modules.f dmftproj.f readcomline.f set_ang_trans.f setsym.f
 
 # The main target and what to link with...
 add_executable(dmftproj ${SOURCES})
+
+# ---------------------------------------------------------------------
+# ------ No 1. failed test to get Lapack libs from triqs
+# ---------------------------------------------------------------------
+
+# -- trying to TRIQS_LIBRARY_LAPACK from the triqs target
+# -- results in ${TRIQS_LIBRARY_LAPACK} == TRIQS_LIBRARY_LAPACK-NOTFOUND
+#get_target_property(TRIQS_LIBRARY_LAPACK triqs TRIQS_LIBRARY_LAPACK)
+
+# -- when doing nothing ${TRIQS_LIBRARY_LAPACK} is just empty
+message(STATUS "Lapack libraries linked with dmftproj: ${TRIQS_LIBRARY_LAPACK}")
+
 target_link_libraries(dmftproj ${TRIQS_LIBRARY_LAPACK})
+
+# ---------------------------------------------------------------------
+# ------ No 2. failed test to get Lapack libs from triqs
+# ---------------------------------------------------------------------
+
+#target_link_libraries(dmftproj triqs) # does not work due to "-stdlib=" flag..
+
+# ---------------------------------------------------------------------
+# BEGIN Workaround only working on Mac
+# ---------------------------------------------------------------------
+
+target_link_libraries(dmftproj "-framework Accelerate")
+
+# ---------------------------------------------------------------------
+# END Workaround
+# ---------------------------------------------------------------------
 
 # where to install
 install (TARGETS dmftproj DESTINATION bin)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -3,6 +3,9 @@
 
 #configure_file(${CMAKE_SOURCE_DIR}/cmake/sitecustomize.py ${CMAKE_CURRENT_BINARY_DIR}/sitecustomize.py @ONLY)
 
+# The std for all targets
+add_compile_options(-std=c++1z)
+
 # add version file
 configure_file(version.py.in version.py)
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,16 +1,23 @@
-# where will the python end up in triqs?
-set(python_destination pytriqs/applications/dft)
-
 # site_customize for build
-set(package_name "pytriqs.applications")
-configure_file(${CMAKE_SOURCE_DIR}/cmake/sitecustomize.py ${CMAKE_CURRENT_BINARY_DIR}/sitecustomize.py @ONLY)
+#set(package_name "pytriqs.applications")
 
-# make a local pytriqs copy
-triqs_prepare_local_pytriqs(${python_destination})
-
-# VASP converter
-add_subdirectory(converters/plovasp)
+#configure_file(${CMAKE_SOURCE_DIR}/cmake/sitecustomize.py ${CMAKE_CURRENT_BINARY_DIR}/sitecustomize.py @ONLY)
 
 # add version file
 configure_file(version.py.in version.py)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/version.py DESTINATION ${TRIQS_PYTHON_LIB_DEST_ROOT}/${python_destination})
+
+set(PYTHON_LIB_DEST ${CPP2PY_PYTHON_LIB_DEST_ROOT}/triqs_dft_tools)
+
+set(PYTHON_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/block_structure.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/clear_h5_output.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/sumk_dft.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/sumk_dft_tools.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/symmetry.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/trans_basis.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/update_archive.py)
+
+install(FILES ${PYTHON_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/version.py DESTINATION ${PYTHON_LIB_DEST})
+
+add_subdirectory(converters)

--- a/python/converters/CMakeLists.txt
+++ b/python/converters/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+set(PYTHON_LIB_DEST ${CPP2PY_PYTHON_LIB_DEST_ROOT}/triqs_dft_tools)
+
+set(PYTHON_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/converter_tools.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/hk_converter.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/vasp_converter.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/wannier90_converter.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/wien2k_converter.py)
+
+install(FILES ${PYTHON_SOURCES} DESTINATION ${PYTHON_LIB_DEST}/converters)
+
+# VASP converter
+add_subdirectory(plovasp)

--- a/python/converters/converter_tools.py
+++ b/python/converters/converter_tools.py
@@ -19,9 +19,10 @@
 # TRIQS. If not, see <http://www.gnu.org/licenses/>.
 #
 ##########################################################################
+
+import os
 from pytriqs.cmake_info import hdf5_command_path
 import pytriqs.utility.mpi as mpi
-
 
 class ConverterTools:
 
@@ -73,7 +74,7 @@ class ConverterTools:
         mpi.report("Repacking the file %s" % self.hdf_file)
 
         retcode = subprocess.call(
-            [hdf5_command_path + "/h5repack", "-i%s" % self.hdf_file, "-otemphgfrt.h5"])
+            [os.path.join(hdf5_command_path, "h5repack"), "-i%s" % self.hdf_file, "-otemphgfrt.h5"])
         if retcode != 0:
             mpi.report("h5repack failed!")
         else:

--- a/python/converters/plovasp/CMakeLists.txt
+++ b/python/converters/plovasp/CMakeLists.txt
@@ -1,11 +1,22 @@
-set(python_destination pytriqs/applications/dft/converters/plovasp)
+
+set(python_destination plovasp)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${TRIQS_INCLUDE_ALL})
-triqs_python_extension(atm ${python_destination})
-target_link_libraries(atm atm_c ${TRIQS_LIBRARY_ALL})
-triqs_set_rpath_for_target(atm)
+add_cpp2py_module(atm)
+target_link_libraries(atm atm_c)
 
-# This we need in order for tests to work
-add_custom_command(TARGET atm POST_BUILD COMMAND ln -fs ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}/atm.so ${CMAKE_BINARY_DIR}/python/dft/converters/plovasp)
+set(PYTHON_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/atm_desc.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/converter.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/elstruct.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/inpconf.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/plotools.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/proj_group.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/proj_shell.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/sc_dmft.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/vaspio.py)
 
-install (TARGETS atm DESTINATION ${TRIQS_PYTHON_LIB_DEST_ROOT}/${python_destination})
+set(PYTHON_LIB_DEST ${CPP2PY_PYTHON_LIB_DEST_ROOT}/triqs_dft_tools)
+install(FILES ${PYTHON_SOURCES} DESTINATION ${PYTHON_LIB_DEST}/converters/plovasp)
+install (TARGETS atm DESTINATION ${PYTHON_LIB_DEST}/converters/plovasp)

--- a/python/converters/plovasp/atm_desc.py
+++ b/python/converters/plovasp/atm_desc.py
@@ -1,6 +1,6 @@
 # Generated automatically using the command :
 # c++2py.py -m atm -o atm --moduledoc "Analytical Tetrahedron Method for DOS" ../../../c++/plovasp/atm/dos_tetra3d.hpp
-from wrap_generator import *
+from cpp2py.wrap_generator import *
 
 # The module
 module = module_(full_name = "atm", doc = "Analytical Tetrahedron Method for calculating DOS", app_name = "atm")
@@ -12,7 +12,7 @@ module.add_include("../../../c++/plovasp/atm/dos_tetra3d.hpp")
 
 # Add here anything to add in the C++ code at the start, e.g. namespace using
 module.add_preamble("""
-#include <triqs/python_tools/converters/arrays.hpp>
+#include <triqs/cpp2py_converters/arrays.hpp>
 """)
 
 module.add_function ("array_view<double,2> dos_tetra_weights_3d (array_view<double,1> eigk, double en, array_view<long,2> itt)", doc = """DOS of a band by analytical tetrahedron method\n\n   Returns corner weights for all tetrahedra for a given band and real energy.""")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,20 +1,19 @@
-# load triqs helper to set up tests
-find_package(TriqsTest)
 
 # Copy h5 files to binary dir
 FILE(GLOB all_h5_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.h5)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/${all_h5_files} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
 # Copy other files
 FILE(COPY SrVO3.pmat SrVO3.struct SrVO3.outputs SrVO3.oubwin SrVO3.ctqmcout SrVO3.symqmc SrVO3.sympar SrVO3.parproj hk_convert_hamiltonian.hk LaVO3-Pnma_hr.dat LaVO3-Pnma.inp DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-triqs_add_python_test(wien2k_convert)
-triqs_add_python_test(hk_convert)
-triqs_add_python_test(w90_convert)
-triqs_add_python_test(sumkdft_basic)
-triqs_add_python_test(srvo3_Gloc)
-triqs_add_python_test(srvo3_transp)
-triqs_add_python_test(sigma_from_file)
-triqs_add_python_test(blockstructure)
+set(all_tests wien2k_convert hk_convert w90_convert sumkdft_basic srvo3_Gloc srvo3_transp sigma_from_file blockstructure)
+
+foreach(t ${all_tests})
+  add_test(NAME ${t} COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/${t}.py)
+endforeach()
+
+# Set the PythonPath : put the build dir first (in case there is an installed version). 
+set_property(TEST ${all_tests} PROPERTY ENVIRONMENT PYTHONPATH=${CMAKE_BINARY_DIR}/python:$ENV{PYTHONPATH} )
 
 # VASP converter tests
 add_subdirectory(plovasp)

--- a/test/blockstructure.py
+++ b/test/blockstructure.py
@@ -1,8 +1,11 @@
-from pytriqs.applications.dft.sumk_dft import *
 from pytriqs.utility.h5diff import h5diff
 from pytriqs.gf import *
+from pytriqs.archive import HDFArchive
+import pytriqs.utility.mpi as mpi
 from pytriqs.utility.comparison_tests import assert_block_gfs_are_close
-from pytriqs.applications.dft import BlockStructure
+
+from triqs_dft_tools import BlockStructure
+from triqs_dft_tools.sumk_dft import SumkDFT
 
 SK = SumkDFT('blockstructure.in.h5',use_dft_blocks=True)
 

--- a/test/hk_convert.py
+++ b/test/hk_convert.py
@@ -21,10 +21,11 @@
 ################################################################################
 
 
-from pytriqs.applications.dft.converters import *
 from pytriqs.archive import *
 from pytriqs.utility.h5diff import h5diff
 import pytriqs.utility.mpi as mpi
+
+from triqs_dft_tools.converters import HkConverter
 
 Converter = HkConverter(filename='hk_convert_hamiltonian.hk',hdf_filename='hk_convert.out.h5')
 

--- a/test/plovasp/CMakeLists.txt
+++ b/test/plovasp/CMakeLists.txt
@@ -12,6 +12,5 @@ FILE(COPY ${TestSuites} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 FILE(COPY run_suite.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 foreach(test_suite ${TestSuites})
-    add_test(${test_suite}
-      ${PythonBuildExecutable} run_suite.py ${test_suite})
+  add_test(NAME ${test_suite} COMMAND python run_suite.py ${test_suite})
 endforeach(test_suite ${TestSuites})

--- a/test/plovasp/atm/test_atm.py
+++ b/test/plovasp/atm/test_atm.py
@@ -2,7 +2,7 @@
 import os
 
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.atm import dos_tetra_weights_3d
+from triqs_dft_tools.converters.plovasp.atm import dos_tetra_weights_3d
 import mytest
 
 ################################################################################

--- a/test/plovasp/inpconf/test_general.py
+++ b/test/plovasp/inpconf/test_general.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import arraytest
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
 
 ################################################################################
 #

--- a/test/plovasp/inpconf/test_groups.py
+++ b/test/plovasp/inpconf/test_groups.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import arraytest
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
 
 ################################################################################
 #

--- a/test/plovasp/inpconf/test_input.py
+++ b/test/plovasp/inpconf/test_input.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import arraytest
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
 
 ################################################################################
 #

--- a/test/plovasp/inpconf/test_parameter_set.py
+++ b/test/plovasp/inpconf/test_parameter_set.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import arraytest
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
 
 ################################################################################
 #

--- a/test/plovasp/inpconf/test_shells.py
+++ b/test/plovasp/inpconf/test_shells.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import arraytest
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
 
 ################################################################################
 #

--- a/test/plovasp/inpconf/test_special_parsers.py
+++ b/test/plovasp/inpconf/test_special_parsers.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import arraytest
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
 
 ################################################################################
 #

--- a/test/plovasp/plotools/test_consistency.py
+++ b/test/plovasp/plotools/test_consistency.py
@@ -1,8 +1,8 @@
 
-import pytriqs.applications.dft.converters.plovasp.vaspio
-from pytriqs.applications.dft.converters.plovasp.inpconf import ConfigParameters
-from pytriqs.applications.dft.converters.plovasp.plotools import check_data_consistency
-from pytriqs.applications.dft.converters.plovasp.elstruct import ElectronicStructure
+import triqs_dft_tools.converters.plovasp.vaspio
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.plotools import check_data_consistency
+from triqs_dft_tools.converters.plovasp.elstruct import ElectronicStructure
 import mytest
 
 ################################################################################

--- a/test/plovasp/proj_group/test_block_map.py
+++ b/test/plovasp/proj_group/test_block_map.py
@@ -4,9 +4,9 @@ import rpath
 _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.inpconf import ConfigParameters
-from pytriqs.applications.dft.converters.plovasp.proj_shell import ProjectorShell
-from pytriqs.applications.dft.converters.plovasp.proj_group import ProjectorGroup
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.proj_shell import ProjectorShell
+from triqs_dft_tools.converters.plovasp.proj_group import ProjectorGroup
 import mytest
 
 ################################################################################

--- a/test/plovasp/proj_group/test_one_site.py
+++ b/test/plovasp/proj_group/test_one_site.py
@@ -4,11 +4,11 @@ import rpath
 _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.vaspio import VaspData
-from pytriqs.applications.dft.converters.plovasp.elstruct import ElectronicStructure
-from pytriqs.applications.dft.converters.plovasp.inpconf import ConfigParameters
-from pytriqs.applications.dft.converters.plovasp.proj_shell import ProjectorShell
-from pytriqs.applications.dft.converters.plovasp.proj_group import ProjectorGroup
+from triqs_dft_tools.converters.plovasp.vaspio import VaspData
+from triqs_dft_tools.converters.plovasp.elstruct import ElectronicStructure
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.proj_shell import ProjectorShell
+from triqs_dft_tools.converters.plovasp.proj_group import ProjectorGroup
 from pytriqs.archive import HDFArchive
 import mytest
 

--- a/test/plovasp/proj_group/test_select_bands.py
+++ b/test/plovasp/proj_group/test_select_bands.py
@@ -4,11 +4,11 @@ import rpath
 _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.vaspio import VaspData
-from pytriqs.applications.dft.converters.plovasp.elstruct import ElectronicStructure
-from pytriqs.applications.dft.converters.plovasp.inpconf import ConfigParameters
-from pytriqs.applications.dft.converters.plovasp.proj_shell import ProjectorShell
-from pytriqs.applications.dft.converters.plovasp.proj_group import ProjectorGroup
+from triqs_dft_tools.converters.plovasp.vaspio import VaspData
+from triqs_dft_tools.converters.plovasp.elstruct import ElectronicStructure
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.proj_shell import ProjectorShell
+from triqs_dft_tools.converters.plovasp.proj_group import ProjectorGroup
 import mytest
 
 ################################################################################

--- a/test/plovasp/proj_group/test_two_site.py
+++ b/test/plovasp/proj_group/test_two_site.py
@@ -4,11 +4,11 @@ import rpath
 _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.vaspio import VaspData
-from pytriqs.applications.dft.converters.plovasp.elstruct import ElectronicStructure
-from pytriqs.applications.dft.converters.plovasp.inpconf import ConfigParameters
-from pytriqs.applications.dft.converters.plovasp.proj_shell import ProjectorShell
-from pytriqs.applications.dft.converters.plovasp.proj_group import ProjectorGroup
+from triqs_dft_tools.converters.plovasp.vaspio import VaspData
+from triqs_dft_tools.converters.plovasp.elstruct import ElectronicStructure
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.proj_shell import ProjectorShell
+from triqs_dft_tools.converters.plovasp.proj_group import ProjectorGroup
 from pytriqs.archive import HDFArchive
 import mytest
 

--- a/test/plovasp/proj_shell/test_projshells.py
+++ b/test/plovasp/proj_shell/test_projshells.py
@@ -4,11 +4,11 @@ import rpath
 _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.vaspio import VaspData
-from pytriqs.applications.dft.converters.plovasp.elstruct import ElectronicStructure
-from pytriqs.applications.dft.converters.plovasp.inpconf import ConfigParameters
-from pytriqs.applications.dft.converters.plovasp.proj_shell import ProjectorShell
-from pytriqs.applications.dft.converters.plovasp.proj_group import ProjectorGroup
+from triqs_dft_tools.converters.plovasp.vaspio import VaspData
+from triqs_dft_tools.converters.plovasp.elstruct import ElectronicStructure
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.proj_shell import ProjectorShell
+from triqs_dft_tools.converters.plovasp.proj_group import ProjectorGroup
 import mytest
 
 ################################################################################

--- a/test/plovasp/vaspio/test_doscar.py
+++ b/test/plovasp/vaspio/test_doscar.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import mytest
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.vaspio import Doscar
+from triqs_dft_tools.converters.plovasp.vaspio import Doscar
 
 ################################################################################
 #

--- a/test/plovasp/vaspio/test_eigenval.py
+++ b/test/plovasp/vaspio/test_eigenval.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import mytest
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.vaspio import Eigenval
+from triqs_dft_tools.converters.plovasp.vaspio import Eigenval
 
 ################################################################################
 #

--- a/test/plovasp/vaspio/test_kpoints.py
+++ b/test/plovasp/vaspio/test_kpoints.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import mytest
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.vaspio import Kpoints
+from triqs_dft_tools.converters.plovasp.vaspio import Kpoints
 
 ################################################################################
 #

--- a/test/plovasp/vaspio/test_poscar.py
+++ b/test/plovasp/vaspio/test_poscar.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import mytest
 import numpy as np
-from pytriqs.applications.dft.converters.plovasp.vaspio import Poscar
+from triqs_dft_tools.converters.plovasp.vaspio import Poscar
 
 ################################################################################
 #

--- a/test/sigma_from_file.py
+++ b/test/sigma_from_file.py
@@ -22,9 +22,10 @@
 from pytriqs.archive import *
 from pytriqs.gf import *
 from pytriqs.gf.tools import *
-from pytriqs.applications.dft.sumk_dft_tools import *
 from pytriqs.utility.comparison_tests import *
 import numpy as np
+
+from triqs_dft_tools.sumk_dft_tools import SumkDFTTools
 
 # Read self energy from hdf file
 ar = HDFArchive('SrVO3_Sigma.h5','r')

--- a/test/srvo3_Gloc.py
+++ b/test/srvo3_Gloc.py
@@ -19,13 +19,16 @@
 #
 ################################################################################
 
-from pytriqs.archive import *
 from pytriqs.gf import *
-from pytriqs.applications.dft.sumk_dft import *
-from pytriqs.applications.dft.converters.wien2k_converter import *
+from pytriqs.archive import HDFArchive
+import pytriqs.utility.mpi as mpi
+
 from pytriqs.operators.util import set_operator_structure
+
 from pytriqs.utility.comparison_tests import *
 from pytriqs.utility.h5diff import h5diff
+
+from triqs_dft_tools.sumk_dft import SumkDFT
 
 # Basic input parameters
 beta = 40

--- a/test/srvo3_transp.py
+++ b/test/srvo3_transp.py
@@ -20,11 +20,13 @@
 ################################################################################
 
 from numpy import *
-from pytriqs.applications.dft.converters.wien2k_converter import *
-from pytriqs.applications.dft.sumk_dft import *
-from pytriqs.applications.dft.sumk_dft_tools import *
+from pytriqs.archive import HDFArchive
 from pytriqs.utility.comparison_tests import *
 from pytriqs.utility.h5diff import h5diff 
+import pytriqs.utility.mpi as mpi
+
+from triqs_dft_tools.converters.wien2k_converter import Wien2kConverter
+from triqs_dft_tools.sumk_dft_tools import SumkDFTTools
 
 beta = 40
 

--- a/test/sumkdft_basic.py
+++ b/test/sumkdft_basic.py
@@ -21,10 +21,11 @@
 ################################################################################
 
 from pytriqs.archive import *
-from pytriqs.applications.dft.sumk_dft_tools import SumkDFTTools
 import pytriqs.utility.mpi as mpi
 from pytriqs.utility.comparison_tests import *
 from pytriqs.utility.h5diff import h5diff 
+
+from triqs_dft_tools.sumk_dft_tools import SumkDFTTools
 
 SK = SumkDFTTools(hdf_file = 'SrVO3.h5')
 

--- a/test/w90_convert.py
+++ b/test/w90_convert.py
@@ -21,10 +21,11 @@
 ################################################################################
 
 
-from pytriqs.applications.dft.converters import *
 from pytriqs.archive import *
 from pytriqs.utility.h5diff import h5diff
 import pytriqs.utility.mpi as mpi
+
+from triqs_dft_tools.converters import Wannier90Converter
 
 Converter = Wannier90Converter(seedname='LaVO3-Pnma',hdf_filename='w90_convert.out.h5')
 

--- a/test/wien2k_convert.py
+++ b/test/wien2k_convert.py
@@ -21,10 +21,11 @@
 ################################################################################
 
 from pytriqs.archive import *
-from pytriqs.applications.dft.converters import Wien2kConverter
 from pytriqs.utility.comparison_tests import *
 from pytriqs.utility.h5diff import h5diff 
 import pytriqs.utility.mpi as mpi
+
+from triqs_dft_tools.converters import Wien2kConverter
 
 Converter = Wien2kConverter(filename='SrVO3')
 Converter.hdf_file = 'wien2k_convert.out.h5'


### PR DESCRIPTION
Dear all,

Here is an attempt to port `dft_tools/unstable` to the recently separated libraries/projects `cpp2py` and `triqs/unstable`. I think I have fixed most problems, except the lapack bindings for the fortran source. See the cmake file `fortran/dmftproj/CMakeLists.txt` below.

@parcollet could you please help we with getting the lapack libs out of `triqs/unstable`?

The previous version relied on the `triqs`-exported variable `${TRIQS_LIBRARY_LAPACK}` and simply issued
```
target_link_libraries(dmftproj ${TRIQS_LIBRARY_LAPACK})
```
with the current `triqs/unstable` this variable is empty, which causes the linking of the fortran source to fail.

I have tried to link directly with the exported `triqs` target by replacing the above with
```
target_link_libraries(dmftproj triqs)
```
which, however, fails with `gfortran: error: unrecognized command line option '-stdlib=libc++'`

I have also tried to fetch it from the `triqs` target
```
get_target_property(TRIQS_LIBRARY_LAPACK triqs TRIQS_LIBRARY_LAPACK)
```
but this results in ` ${TRIQS_LIBRARY_LAPACK} == TRIQS_LIBRARY_LAPACK-NOTFOUND`


Only once this issue is fixed can this pull request be considered for merging.

Best regards,
Hugo