### PR TITLE
Fix use of numpy.full on older numpy

### DIFF
--- a/python/sumk_dft_tools.py
+++ b/python/sumk_dft_tools.py
@@ -28,6 +28,9 @@ from sumk_dft import SumkDFT
 from scipy.integrate import *
 from scipy.interpolate import *
 
+if not hasattr(numpy, 'full'):
+    # polyfill full for older numpy:
+    numpy.full = lambda a, f: numpy.zeros(a) + f
 
 class SumkDFTTools(SumkDFT):
     """


### PR DESCRIPTION
Was failing test srvo3_transp on centos:
```
  File "/home/build/dft_tools/python/sumk_dft_tools.py", line 947, in <dictcomp>
    for direction in self.directions}
AttributeError: 'module' object has no attribute 'full'
```
There are other ways to do this, `numpy.empty(a).fill(f)` for example works too.