### PR TITLE
Test improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ add_subdirectory(fortran/dmftproj)
 message(STATUS "TRIQS : Adding compilation flags detected by the library (C++11/14, libc++, etc...) ")
 
 add_subdirectory(c++)
-add_subdirectory(python)
+add_subdirectory(python python/triqs_dft_tools)
 add_subdirectory(shells)
 
 #------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,24 @@ add_subdirectory(shells)
 #------------------------
 # tests
 #------------------------
- 
+
+option(TEST_COVERAGE "Analyze the coverage of tests" OFF)
+
+# perform tests with coverage info
+if (${TEST_COVERAGE})
+  # we try to locate the coverage program
+  find_program(PYTHON_COVERAGE python-coverage)
+  find_program(PYTHON_COVERAGE coverage)
+  if(NOT PYTHON_COVERAGE)
+      message(FATAL_ERROR "Program coverage (or python-coverage) not found.\nEither set PYTHON_COVERAGE explicitly or disable TEST_COVERAGE!\nYou need to install the python package coverage, e.g. with\n  pip install coverage\nor with\n  apt install python-coverage")
+  endif()
+
+  message(STATUS "Setting up test coverage")
+  add_custom_target(coverage ${PYTHON_COVERAGE} combine --append .coverage plovasp/.coverage || true COMMAND ${PYTHON_COVERAGE} html COMMAND echo "Open ${CMAKE_BINARY_DIR}/test/htmlcov/index.html in browser!" WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test)
+endif()
+
 enable_testing()
- 
+
 option(Build_Tests "Build the tests of the library " ON)
 if (Build_Tests)
   message(STATUS "-------- Preparing tests  -------------")

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -124,3 +124,7 @@ Functionality of ``dft_tools`` can be tweaked using extra compile-time options p
 +---------------------------------------------------------------+-----------------------------------------------+
 | Build the documentation locally                               | -DBuild_Documentation=ON                      |
 +---------------------------------------------------------------+-----------------------------------------------+
+| Check test coverage when testing                              | -DTEST_COVERAGE=ON                            |
+| (run ``make coverage`` to show the results; requires the      |                                               |
+| python ``coverage`` package)                                  |                                               |
++---------------------------------------------------------------+-----------------------------------------------+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,8 +7,14 @@ FILE(COPY SrVO3.pmat SrVO3.struct SrVO3.outputs SrVO3.oubwin SrVO3.ctqmcout SrVO
 # List all tests
 set(all_tests wien2k_convert hk_convert w90_convert sumkdft_basic srvo3_Gloc srvo3_transp sigma_from_file blockstructure analyse_block_structure_from_gf analyse_block_structure_from_gf2)
 
+set(python_executable python)
+
+if(${TEST_COVERAGE})
+    set(python_executable ${PYTHON_COVERAGE} run --append --source "${CMAKE_BINARY_DIR}/python" )
+endif()
+
 foreach(t ${all_tests})
-  add_test(NAME ${t} COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/${t}.py)
+  add_test(NAME ${t} COMMAND ${python_executable} ${CMAKE_CURRENT_SOURCE_DIR}/${t}.py)
 endforeach()
 
 # Set the PythonPath : put the build dir first (in case there is an installed version). 
@@ -17,4 +23,3 @@ set_property(TEST ${all_tests} PROPERTY ENVIRONMENT PYTHONPATH=${CMAKE_BINARY_DI
 
 # VASP converter tests
 add_subdirectory(plovasp)
-

--- a/test/analyse_block_structure_from_gf.py
+++ b/test/analyse_block_structure_from_gf.py
@@ -1,5 +1,5 @@
 from pytriqs.gf import *
-from sumk_dft import SumkDFT
+from triqs_dft_tools.sumk_dft import SumkDFT
 from scipy.linalg import expm
 import numpy as np
 from pytriqs.utility.comparison_tests import assert_gfs_are_close, assert_arrays_are_close, assert_block_gfs_are_close

--- a/test/analyse_block_structure_from_gf2.py
+++ b/test/analyse_block_structure_from_gf2.py
@@ -1,5 +1,5 @@
 from pytriqs.gf import *
-from sumk_dft import SumkDFT
+from triqs_dft_tools.sumk_dft import SumkDFT
 import numpy as np
 from pytriqs.utility.comparison_tests import assert_block_gfs_are_close
 

--- a/test/blockstructure.py
+++ b/test/blockstructure.py
@@ -1,8 +1,8 @@
-from sumk_dft import *
+from triqs_dft_tools.sumk_dft import *
 from pytriqs.utility.h5diff import h5diff
 from pytriqs.gf import *
 from pytriqs.utility.comparison_tests import assert_block_gfs_are_close
-from block_structure import BlockStructure
+from triqs_dft_tools.block_structure import BlockStructure
 
 SK = SumkDFT('blockstructure.in.h5',use_dft_blocks=True)
 

--- a/test/hk_convert.py
+++ b/test/hk_convert.py
@@ -25,7 +25,7 @@ from pytriqs.archive import *
 from pytriqs.utility.h5diff import h5diff
 import pytriqs.utility.mpi as mpi
 
-from converters import *
+from triqs_dft_tools.converters import *
 
 Converter = HkConverter(filename='hk_convert_hamiltonian.hk',hdf_filename='hk_convert.out.h5')
 

--- a/test/plovasp/CMakeLists.txt
+++ b/test/plovasp/CMakeLists.txt
@@ -12,7 +12,7 @@ FILE(COPY ${all_tests} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 FILE(COPY run_suite.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 foreach(t ${all_tests})
-  add_test(NAME ${t} COMMAND python run_suite.py ${t})
+  add_test(NAME ${t} COMMAND ${python_executable} run_suite.py ${t})
 endforeach()
 
 set_property(TEST ${all_tests} PROPERTY ENVIRONMENT PYTHONPATH=${CMAKE_BINARY_DIR}/python:$ENV{PYTHONPATH} )

--- a/test/plovasp/atm/test_atm.py
+++ b/test/plovasp/atm/test_atm.py
@@ -2,7 +2,7 @@
 import os
 
 import numpy as np
-from converters.plovasp.atm import dos_tetra_weights_3d
+from triqs_dft_tools.converters.plovasp.atm import dos_tetra_weights_3d
 import mytest
 
 ################################################################################

--- a/test/plovasp/inpconf/test_general.py
+++ b/test/plovasp/inpconf/test_general.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import arraytest
 import numpy as np
-from converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
 
 ################################################################################
 #

--- a/test/plovasp/inpconf/test_groups.py
+++ b/test/plovasp/inpconf/test_groups.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import arraytest
 import numpy as np
-from converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
 
 ################################################################################
 #

--- a/test/plovasp/inpconf/test_input.py
+++ b/test/plovasp/inpconf/test_input.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import arraytest
 import numpy as np
-from converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
 
 ################################################################################
 #

--- a/test/plovasp/inpconf/test_parameter_set.py
+++ b/test/plovasp/inpconf/test_parameter_set.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import arraytest
 import numpy as np
-from converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
 
 ################################################################################
 #

--- a/test/plovasp/inpconf/test_shells.py
+++ b/test/plovasp/inpconf/test_shells.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import arraytest
 import numpy as np
-from converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
 
 ################################################################################
 #

--- a/test/plovasp/inpconf/test_special_parsers.py
+++ b/test/plovasp/inpconf/test_special_parsers.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import arraytest
 import numpy as np
-from converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
 
 ################################################################################
 #

--- a/test/plovasp/plocar_io/test_fileio.py
+++ b/test/plovasp/plocar_io/test_fileio.py
@@ -3,7 +3,7 @@ Tests of 'read_plocar()' from module 'plocar_io.c_plocar_io'
 """
 import mytest
 import numpy as np
-from plocar_io.c_plocar_io import read_plocar
+from triqs_dft_tools.plocar_io.c_plocar_io import read_plocar
 
 ################################################################################
 #

--- a/test/plovasp/plotools/test_consistency.py
+++ b/test/plovasp/plotools/test_consistency.py
@@ -1,8 +1,8 @@
 
-import converters.plovasp.vaspio
-from converters.plovasp.inpconf import ConfigParameters
-from converters.plovasp.plotools import check_data_consistency
-from converters.plovasp.elstruct import ElectronicStructure
+import triqs_dft_tools.converters.plovasp.vaspio
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.plotools import check_data_consistency
+from triqs_dft_tools.converters.plovasp.elstruct import ElectronicStructure
 import mytest
 
 ################################################################################

--- a/test/plovasp/proj_group/test_block_map.py
+++ b/test/plovasp/proj_group/test_block_map.py
@@ -4,9 +4,9 @@ import rpath
 _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import numpy as np
-from converters.plovasp.inpconf import ConfigParameters
-from converters.plovasp.proj_shell import ProjectorShell
-from converters.plovasp.proj_group import ProjectorGroup
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.proj_shell import ProjectorShell
+from triqs_dft_tools.converters.plovasp.proj_group import ProjectorGroup
 import mytest
 
 ################################################################################

--- a/test/plovasp/proj_group/test_one_site.py
+++ b/test/plovasp/proj_group/test_one_site.py
@@ -4,11 +4,11 @@ import rpath
 _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import numpy as np
-from converters.plovasp.vaspio import VaspData
-from converters.plovasp.elstruct import ElectronicStructure
-from converters.plovasp.inpconf import ConfigParameters
-from converters.plovasp.proj_shell import ProjectorShell
-from converters.plovasp.proj_group import ProjectorGroup
+from triqs_dft_tools.converters.plovasp.vaspio import VaspData
+from triqs_dft_tools.converters.plovasp.elstruct import ElectronicStructure
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.proj_shell import ProjectorShell
+from triqs_dft_tools.converters.plovasp.proj_group import ProjectorGroup
 from pytriqs.archive import HDFArchive
 import mytest
 

--- a/test/plovasp/proj_group/test_select_bands.py
+++ b/test/plovasp/proj_group/test_select_bands.py
@@ -4,11 +4,11 @@ import rpath
 _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import numpy as np
-from converters.plovasp.vaspio import VaspData
-from converters.plovasp.elstruct import ElectronicStructure
-from converters.plovasp.inpconf import ConfigParameters
-from converters.plovasp.proj_shell import ProjectorShell
-from converters.plovasp.proj_group import ProjectorGroup
+from triqs_dft_tools.converters.plovasp.vaspio import VaspData
+from triqs_dft_tools.converters.plovasp.elstruct import ElectronicStructure
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.proj_shell import ProjectorShell
+from triqs_dft_tools.converters.plovasp.proj_group import ProjectorGroup
 import mytest
 
 ################################################################################

--- a/test/plovasp/proj_group/test_two_site.py
+++ b/test/plovasp/proj_group/test_two_site.py
@@ -4,11 +4,11 @@ import rpath
 _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import numpy as np
-from converters.plovasp.vaspio import VaspData
-from converters.plovasp.elstruct import ElectronicStructure
-from converters.plovasp.inpconf import ConfigParameters
-from converters.plovasp.proj_shell import ProjectorShell
-from converters.plovasp.proj_group import ProjectorGroup
+from triqs_dft_tools.converters.plovasp.vaspio import VaspData
+from triqs_dft_tools.converters.plovasp.elstruct import ElectronicStructure
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.proj_shell import ProjectorShell
+from triqs_dft_tools.converters.plovasp.proj_group import ProjectorGroup
 from pytriqs.archive import HDFArchive
 import mytest
 

--- a/test/plovasp/proj_shell/test_projshells.py
+++ b/test/plovasp/proj_shell/test_projshells.py
@@ -4,11 +4,11 @@ import rpath
 _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import numpy as np
-from converters.plovasp.vaspio import VaspData
-from converters.plovasp.elstruct import ElectronicStructure
-from converters.plovasp.inpconf import ConfigParameters
-from converters.plovasp.proj_shell import ProjectorShell
-from converters.plovasp.proj_group import ProjectorGroup
+from triqs_dft_tools.converters.plovasp.vaspio import VaspData
+from triqs_dft_tools.converters.plovasp.elstruct import ElectronicStructure
+from triqs_dft_tools.converters.plovasp.inpconf import ConfigParameters
+from triqs_dft_tools.converters.plovasp.proj_shell import ProjectorShell
+from triqs_dft_tools.converters.plovasp.proj_group import ProjectorGroup
 import mytest
 
 ################################################################################

--- a/test/plovasp/vaspio/test_doscar.py
+++ b/test/plovasp/vaspio/test_doscar.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import mytest
 import numpy as np
-from converters.plovasp.vaspio import Doscar
+from triqs_dft_tools.converters.plovasp.vaspio import Doscar
 
 ################################################################################
 #

--- a/test/plovasp/vaspio/test_eigenval.py
+++ b/test/plovasp/vaspio/test_eigenval.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import mytest
 import numpy as np
-from converters.plovasp.vaspio import Eigenval
+from triqs_dft_tools.converters.plovasp.vaspio import Eigenval
 
 ################################################################################
 #

--- a/test/plovasp/vaspio/test_kpoints.py
+++ b/test/plovasp/vaspio/test_kpoints.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import mytest
 import numpy as np
-from converters.plovasp.vaspio import Kpoints
+from triqs_dft_tools.converters.plovasp.vaspio import Kpoints
 
 ################################################################################
 #

--- a/test/plovasp/vaspio/test_poscar.py
+++ b/test/plovasp/vaspio/test_poscar.py
@@ -7,7 +7,7 @@ _rpath = os.path.dirname(rpath.__file__) + '/'
 
 import mytest
 import numpy as np
-from converters.plovasp.vaspio import Poscar
+from triqs_dft_tools.converters.plovasp.vaspio import Poscar
 
 ################################################################################
 #

--- a/test/sigma_from_file.py
+++ b/test/sigma_from_file.py
@@ -22,7 +22,7 @@
 from pytriqs.archive import *
 from pytriqs.gf import *
 from pytriqs.gf.tools import *
-from sumk_dft_tools import *
+from triqs_dft_tools.sumk_dft_tools import *
 from pytriqs.utility.comparison_tests import *
 import numpy as np
 

--- a/test/srvo3_Gloc.py
+++ b/test/srvo3_Gloc.py
@@ -21,8 +21,8 @@
 
 from pytriqs.archive import *
 from pytriqs.gf import *
-from sumk_dft import *
-from converters.wien2k_converter import *
+from triqs_dft_tools.sumk_dft import *
+from triqs_dft_tools.converters.wien2k_converter import *
 from pytriqs.operators.util import set_operator_structure
 from pytriqs.utility.comparison_tests import *
 from pytriqs.utility.h5diff import h5diff

--- a/test/srvo3_transp.py
+++ b/test/srvo3_transp.py
@@ -20,9 +20,9 @@
 ################################################################################
 
 from numpy import *
-from converters.wien2k_converter import *
-from sumk_dft import *
-from sumk_dft_tools import *
+from triqs_dft_tools.converters.wien2k_converter import *
+from triqs_dft_tools.sumk_dft import *
+from triqs_dft_tools.sumk_dft_tools import *
 from pytriqs.utility.comparison_tests import *
 from pytriqs.utility.h5diff import h5diff 
 

--- a/test/sumkdft_basic.py
+++ b/test/sumkdft_basic.py
@@ -21,7 +21,7 @@
 ################################################################################
 
 from pytriqs.archive import *
-from sumk_dft_tools import SumkDFTTools
+from triqs_dft_tools.sumk_dft_tools import SumkDFTTools
 import pytriqs.utility.mpi as mpi
 from pytriqs.utility.comparison_tests import *
 from pytriqs.utility.h5diff import h5diff 

--- a/test/w90_convert.py
+++ b/test/w90_convert.py
@@ -21,7 +21,7 @@
 ################################################################################
 
 
-from converters import *
+from triqs_dft_tools.converters import *
 from pytriqs.archive import *
 from pytriqs.utility.h5diff import h5diff
 import pytriqs.utility.mpi as mpi

--- a/test/wien2k_convert.py
+++ b/test/wien2k_convert.py
@@ -25,7 +25,7 @@ from pytriqs.utility.comparison_tests import *
 from pytriqs.utility.h5diff import h5diff 
 import pytriqs.utility.mpi as mpi
 
-from converters import Wien2kConverter
+from triqs_dft_tools.converters import Wien2kConverter
 
 Converter = Wien2kConverter(filename='SrVO3')
 Converter.hdf_file = 'wien2k_convert.out.h5'


### PR DESCRIPTION
Hi everyone,

I added two improvements to the tests in TRIQS/DFTTools:

- the python build test environment is now copied not to the folder ``python`` in the build directory but into ``python/triqs_dft_tools``. Thus, in the tests, the imports read e.g. ``from triqs_dft_tools.sumk_dft import SumkDFT`` just as in the *real* python scripts. This has the advantage that users can take the python tests as starting point for developing their own scripts without having to change the import. I modified the imports in the tests accordingly, so that the tests run.
- there is now the CMake option ``-DTEST_COVERAGE=ON`` which uses the python ``coverage`` program (which needs to be installed, if ``TEST_COVERAGE=ON`` is used) to measure the test coverage whenever the tests are run. Using ``make coverage`` a html report is created showing the test coverage incl. analysis which lines are not covered by tests. I think that measuring the coverage is an important first step to actually *increasing* the coverage (which we definitely should do).

Please review and merge if ok.