### PR TITLE
fixed a slicing bug for the calculation of the target density of the VASP converter

### DIFF
--- a/python/converters/plovasp/proj_group.py
+++ b/python/converters/plovasp/proj_group.py
@@ -94,7 +94,7 @@ class ProjectorGroup:
         for isp in xrange(ns_band):
             for ik in xrange(nk):
                 ib1 = self.ib_win[ik, isp, 0]
-                ib2 = self.ib_win[ik, isp, 1]
+                ib2 = self.ib_win[ik, isp, 1]+1
                 occ = el_struct.ferw[isp, ik, ib1:ib2]
                 kwght = el_struct.kmesh['kweights'][ik]
                 self.nelect += occ.sum() * kwght * rspin


### PR DESCRIPTION
This bug selected one band less than expected for the calculation of the target density. Should be fixed immediately in stable branch. Is already fixed in unstable. Affects all Vasp converter users. Briefly cross-checked by @malte-schueler as well. 