### PR TITLE
dmftproj: add option to specify band indices

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -8,6 +8,7 @@ DFTTools Version 3.0.0 is a major release that
 * is now aligned with the general [app4triqs](https://github.com/TRIQS/app4triqs) application skeleton
 * brings a major rework of the VASP interface, including thorough documentation, tutorials, a new Hamiltonian mode, the option to select bands instead of an energy window, and many small bugfixes.
 * brings a major update of the block structure functionalities especially for SOC calculations, with detailed documentation and tutorials. Allows more control over the block structure coming from DFT, cutting out certain orbitals or throwing away off-diagonal elements when preparing input for the solver.
+* New option in dmftproj to select the projection window using band indices instead of energie
 
 Restructuring
 -------------
@@ -65,7 +66,7 @@ other changes:
 
 
 Thanks to all commit-contributors (in alphabetical order):
-Markus Aichhorn, Alexander Hampel, Oleg Peil, Hermann Schnait, Malte Schueler, Nils Wentzell, Manuel Zingl
+Markus Aichhorn, Alexander Hampel, Gernot Kraberger, Oleg Peil, Hermann Schnait, Malte Schueler, Nils Wentzell, Manuel Zingl
 
 
 Version 2.2.1

--- a/doc/guide/conv_wien2k.rst
+++ b/doc/guide/conv_wien2k.rst
@@ -68,9 +68,30 @@ is given by the following 3 to 5 lines:
 
 These lines have to be repeated for each inequivalent atom.
 
-The last line gives the energy window, relative to the Fermi energy,
-that is used for the projective Wannier functions. Note that, in
-accordance with Wien2k, we give energies in Rydberg units!
+The last line gives the lower and upper limit of the energy window,
+relative to the Fermi energy, which is used for the projective Wannier functions.
+Note that, in accordance with Wien2k, we give energies in Rydberg units!
+
+The third number is an optional flag to switch between different modes:
+
+#. 0: The projectors are constructed for the given energy window. The number
+   of bands within the window is usually different at each k-point which
+   will be reflected by the projectors, too. This is the default mode
+   which is also used if no mode flag is provided.
+#. 1: The lowest and highest band indices within the given energy window
+   are calculated. The resulting indices are used at all k-points.
+   Bands which fall within the window only in some parts of the Brillouin zone
+   are fully taken into account. Keep in mind that a different set of k-points
+   or the -band option can change the lower or upper index. This can be avoided
+   by using mode 2.
+#. 2: In this mode the first two values of the line are interpreted as lower
+   and upper band indices to be included in the projective subspace. For example,
+   if the line reads `21 23 2`, bands number 21, 22 and 23 are included at all
+   k-points. For SrVO3 this corresponds to the t2g bands around the Fermi energy.
+   The lowest possible index is 1. Note that the indices need to be provided as integer.
+
+In all modes the used energy range, i.e. band range, is printed to the
+:program:`dmftproj` output.
 
 After setting up the :file:`case.indmftpr` input file, you run:
 

--- a/doc/tutorials/images_scripts/SrVO3.indmftpr
+++ b/doc/tutorials/images_scripts/SrVO3.indmftpr
@@ -12,4 +12,4 @@ cubic            ! choice of angular harmonics
 complex          ! choice of angular harmonics
 1 1 0 0          ! l included for each sort
 0 0 0 0          ! If split into ireps, gives number of ireps. for a given orbital (otherwise 0)
--0.11 0.14
+-0.11 0.14  0    ! lower energy window limit, upper energy window limit, mode (0,1,2)

--- a/fortran/dmftproj/modules.f
+++ b/fortran/dmftproj/modules.f
@@ -68,10 +68,12 @@ C     &    '/workpmc/martins/DMFTprojectors/newDMFTproj'
         INTEGER, DIMENSION(:,:), ALLOCATABLE :: lsort
         INTEGER, DIMENSION(:), ALLOCATABLE :: ifSOflag
         INTEGER, DIMENSION(:), ALLOCATABLE :: timeflag
+        INTEGER :: b_bot, b_top, proj_mode
         LOGICAL :: ifSO, ifSP, ifBAND
         LOGICAL, DIMENSION(:), ALLOCATABLE :: notinclude
         REAL(KIND=8) :: eferm
         REAL(KIND=8) :: e_bot, e_top
+
         REAL(KIND=8), PARAMETER :: PI=3.1415926535898d0
 C New type structure basistrans
         TYPE deftrans


### PR DESCRIPTION
This commit adds the option in dmftproj to select the projective window using a lower and upper band index instead of an energy window. Using band indices guaranties that the number of included bands is the same at all k-points, which is usually not the case using an energy window.