### PR TITLE
Fix bugs in website tutorial 

### DIFF
--- a/doc/guide/dftdmft_selfcons.rst
+++ b/doc/guide/dftdmft_selfcons.rst
@@ -37,7 +37,7 @@ that for one-shot calculations. Only at the very end we have to calculate the mo
 and store it in a format such that Wien2k can read it. Therefore, after the DMFT loop that we saw in the
 previous section, we symmetrise the self energy, and recalculate the impurity Green function::
 
-  SK.symm_deg_gf(S.Sigma,orb=0)
+  SK.symm_deg_gf(S.Sigma,ish=0)
   S.G_iw << inverse(S.G0_iw) - S.Sigma_iw
   S.G_iw.invert()
 

--- a/doc/tutorials/images_scripts/dft_dmft_cthyb.py
+++ b/doc/tutorials/images_scripts/dft_dmft_cthyb.py
@@ -19,10 +19,6 @@ h_field = 0.0
 U = 4.0
 J = 0.65
 dc_type = 1                      # DC type: 0 FLL, 1 Held, 2 AMF
-# Construct U matrix for density-density calculations
-Umat, Upmat = U_matrix_kanamori(n_orb=n_orb, U_int=U, J_hund=J)
-# Construct density-density Hamiltonian
-h_int = h_int_density(spin_names, orb_names, map_operator_structure=SK.sumk_to_solver[0], U=Umat, Uprime=Upmat)
 
 ## SLATER HAMILTONIAN
 ## Define interaction paramters, DC and Hamiltonian
@@ -74,6 +70,10 @@ n_orb = SK.corr_shells[0]['dim']
 l = SK.corr_shells[0]['l']
 spin_names = ["up","down"]
 orb_names = [i for i in range(n_orb)]
+# Construct U matrix for density-density calculations
+Umat, Upmat = U_matrix_kanamori(n_orb=n_orb, U_int=U, J_hund=J)
+# Construct density-density Hamiltonian
+h_int = h_int_density(spin_names, orb_names, map_operator_structure=SK.sumk_to_solver[0], U=Umat, Uprime=Upmat)
 
 # Use GF structure determined by DFT blocks
 gf_struct = [(block, indices) for block, indices in SK.gf_struct_solver[0].items()]

--- a/doc/tutorials/images_scripts/dft_dmft_cthyb.py
+++ b/doc/tutorials/images_scripts/dft_dmft_cthyb.py
@@ -99,7 +99,7 @@ if previous_present:
 for iteration_number in range(1,loops+1):
     if mpi.is_master_node(): print("Iteration = ", iteration_number)
 
-    SK.symm_deg_gf(S.Sigma_iw,orb=0)                        # symmetrise Sigma
+    SK.symm_deg_gf(S.Sigma_iw,ish=0)                        # symmetrise Sigma
     SK.set_Sigma([ S.Sigma_iw ])                            # set Sigma into the SumK class
     chemical_potential = SK.calc_mu( precision = prec_mu )  # find the chemical potential for given density
     S.G_iw << SK.extract_G_loc()[0]                         # calc the local Green function

--- a/doc/tutorials/images_scripts/nio.py
+++ b/doc/tutorials/images_scripts/nio.py
@@ -113,11 +113,11 @@ SK.dc_energ = mpi.bcast(SK.dc_energ)
 SK.chemical_potential = mpi.bcast(SK.chemical_potential)
 
 # Calc the first G0
-SK.symm_deg_gf(S.Sigma_iw,orb=0)
+SK.symm_deg_gf(S.Sigma_iw, ish=0)
 SK.put_Sigma(Sigma_imp = [S.Sigma_iw])
 SK.calc_mu(precision=0.01)
 S.G_iw << SK.extract_G_loc()[0]
-SK.symm_deg_gf(S.G_iw, orb=0)
+SK.symm_deg_gf(S.G_iw, ish=0)
 
 #Init the DC term and the self-energy if no previous iteration was found
 if iteration_offset == 0:
@@ -145,7 +145,7 @@ for it in range(iteration_offset, iteration_offset + n_iterations):
     dm = S.G_iw.density()
     SK.calc_dc(dm, U_interact=U, J_hund=J, orb=0, use_dc_formula=DC_type,use_dc_value=DC_value)
     # Get new G
-    SK.symm_deg_gf(S.Sigma_iw,orb=0)
+    SK.symm_deg_gf(S.Sigma_iw, ish=0)
     SK.put_Sigma(Sigma_imp=[S.Sigma_iw])
     SK.calc_mu(precision=0.01)
     S.G_iw << SK.extract_G_loc()[0]

--- a/doc/tutorials/images_scripts/nio_csc.py
+++ b/doc/tutorials/images_scripts/nio_csc.py
@@ -120,11 +120,11 @@ def dmft_cycle():
     SK.chemical_potential = mpi.bcast(SK.chemical_potential)
     
     # Calc the first G0
-    SK.symm_deg_gf(S.Sigma_iw,orb=0)
+    SK.symm_deg_gf(S.Sigma_iw, ish=0)
     SK.put_Sigma(Sigma_imp = [S.Sigma_iw])
     SK.calc_mu(precision=0.01)
     S.G_iw << SK.extract_G_loc()[0]
-    SK.symm_deg_gf(S.G_iw, orb=0)
+    SK.symm_deg_gf(S.G_iw, ish=0)
     
     #Init the DC term and the self-energy if no previous iteration was found
     if iteration_offset == 0:
@@ -153,7 +153,7 @@ def dmft_cycle():
         dm = S.G_iw.density()
         SK.calc_dc(dm, U_interact=U, J_hund=J, orb=0, use_dc_formula=DC_type,use_dc_value=DC_value)
         # Get new G
-        SK.symm_deg_gf(S.Sigma_iw,orb=0)
+        SK.symm_deg_gf(S.Sigma_iw, ish=0)
         SK.put_Sigma(Sigma_imp=[S.Sigma_iw])
         SK.calc_mu(precision=0.01)
         S.G_iw << SK.extract_G_loc()[0]

--- a/doc/tutorials/srvo3.rst
+++ b/doc/tutorials/srvo3.rst
@@ -187,7 +187,7 @@ some additional refinements::
   for iteration_number in range(1,loops+1):
       if mpi.is_master_node(): print "Iteration = ", iteration_number
 
-      SK.symm_deg_gf(S.Sigma_iw,orb=0)                        # symmetrizing Sigma
+      SK.symm_deg_gf(S.Sigma_iw,ish=0)                        # symmetrizing Sigma
       SK.set_Sigma([ S.Sigma_iw ])                            # put Sigma into the SumK class
       chemical_potential = SK.calc_mu( precision = prec_mu )  # find the chemical potential for given density
       S.G_iw << SK.extract_G_loc()[0]                         # calc the local Green function


### PR DESCRIPTION
Dear Develops,

I find two bugs in the current website tutorial examples, one is the in the `dft_dmft_cthyb`, the Coulomb matrix is setting before the orbital setting. That does not allow one to construct the U matrix. 

Another bug is about the method `symm_deg_gf`, which has another optional variable name `ish`, and is not `orb`. So I correct them in the tutorial example codes. 

Best regards.
