### PR TITLE
Converters can be run in non-MPI environment

### DIFF
--- a/python/triqs_dft_tools/converters/_mpi.py
+++ b/python/triqs_dft_tools/converters/_mpi.py
@@ -13,6 +13,6 @@ def is_master_node():
 def report(message):
     if is_mpi_loaded():
         import triqs.utility.mpi as mpi
-        return mpi.report(message)
+        mpi.report(message)
     else:
         print(message)

--- a/python/triqs_dft_tools/converters/_mpi.py
+++ b/python/triqs_dft_tools/converters/_mpi.py
@@ -1,0 +1,18 @@
+import sys
+
+def is_mpi_loaded():
+    return 'triqs.utility.mpi' in sys.modules
+
+def is_master_node():
+    if is_mpi_loaded():
+        import triqs.utility.mpi as mpi
+        return mpi.is_master_node()
+    else:
+        return True
+
+def report(message):
+    if is_mpi_loaded():
+        import triqs.utility.mpi as mpi
+        return mpi.report(message)
+    else:
+        print(message)

--- a/python/triqs_dft_tools/converters/converter_tools.py
+++ b/python/triqs_dft_tools/converters/converter_tools.py
@@ -19,7 +19,7 @@
 # TRIQS. If not, see <http://www.gnu.org/licenses/>.
 #
 ##########################################################################
-import triqs.utility.mpi as mpi
+from . import _mpi as mpi
 
 class ConverterTools:
 

--- a/python/triqs_dft_tools/converters/hk.py
+++ b/python/triqs_dft_tools/converters/hk.py
@@ -23,7 +23,7 @@
 from types import *
 import numpy
 from h5 import *
-import triqs.utility.mpi as mpi
+from . import _mpi as mpi
 from math import sqrt
 from .converter_tools import *
 


### PR DESCRIPTION
This modification allows the user to use converters in a non-MPI environment.
Please refer to #162.