### PR TITLE
Added parameter kpts_to_write to SumkDFT.calc_density_correction

### DIFF
--- a/python/triqs_dft_tools/sumk_dft.py
+++ b/python/triqs_dft_tools/sumk_dft.py
@@ -1997,7 +1997,7 @@ class SumkDFT(object):
                    DFT code to write the density correction for. Options:
                    'vasp', 'wien2k', 'elk'
         kpts_to_write : iterable of int
-                   Selects k points that are written to file. If None (default),
+                   Indices of k points that are written to file. If None (default),
                    all k points are written. Only implemented for dm_type 'vasp'
 
         Returns


### PR DESCRIPTION
Default behavior unchanged. If parameter `kpts_to_write` is given and if `dm_type=='vasp'`, only the selected k points are written to the density correction GAMMA file.
Can be used for running Vasp with symmetries, where Vasp requires only the density correction from the irreducible Brillouin zone.