### PR TITLE
Bugfix in block_structure.py for multi-shell-systems

### DIFF
--- a/python/triqs_dft_tools/block_structure.py
+++ b/python/triqs_dft_tools/block_structure.py
@@ -997,7 +997,7 @@ class BlockStructure(object):
                     maxdiff = G_back[name] - G[name]
 
                 if space_to == 'solver' and self == G_struct: # do comparison in solver (ignore diff. in ignored orbitals)
-                    tmp = self.create_matrix(space='sumk')
+                    tmp = self.create_matrix(space='sumk', ish=ish_from)
                     tmp[name] = maxdiff
                     maxdiff = G_struct._convert_gf_or_matrix(tmp, self, ish_from=ish_from,
                                                     ish_to=ish_to,


### PR DESCRIPTION
In the case that one has multiple shells with different number of orbitals (e.g. p-d-systems) the old code crashed when converting GFs from the second shell as matrix dimensions were not fitting (the tmp matrix was always created for the first shell).