### PR TITLE
Normalization of kwghts in plovasp

### DIFF
--- a/python/triqs_dft_tools/converters/plovasp/vaspio.py
+++ b/python/triqs_dft_tools/converters/plovasp/vaspio.py
@@ -504,7 +504,7 @@ class Kpoints:
             self.kpts[ik, :] = list(map(float, sline[:3]))
             self.kwghts[ik] = float(sline[3])
 
-        self.kwghts /= self.nktot
+        self.kwghts /= np.sum(self.kwghts)
 
 # Attempt to read tetrahedra
 #   Skip comment line ("Tetrahedra")


### PR DESCRIPTION
Reference:
#172

Fixes:
Only the relative weights of KPOINTS in VASP matter, so when plovasp normalizes by the total number of k-points the weights will be incorrect. Additionally, normalizing by nktot prevents the use of symmetries in VASP.

Unchecked:
As far as I can tell everything else is in plovasp correctly calculates using kwghts, but I did an audit with grep to see if nktot is incorrectly used as normalization in other areas.