### PR TITLE
Bugfixes in blockstructure.py in case of n_corr_shells != n_inequiv_shells

### DIFF
--- a/python/triqs_dft_tools/block_structure.py
+++ b/python/triqs_dft_tools/block_structure.py
@@ -416,8 +416,12 @@ class BlockStructure(object):
             new_gf_struct[ish][block]=list of indices in that block.
         """
 
+        assert len(self.gf_struct_solver) == len(new_gf_struct),\
+            "new_gf_struct has the wrong length"
+
+
         for ish in range(len(self.gf_struct_solver)):
-            gf_struct = new_gf_struct[ish]
+            gf_struct = new_gf_struct[ish].copy()
 
             # create new solver_to_sumk
             so2su = {}
@@ -507,7 +511,7 @@ class BlockStructure(object):
         """
         eff_trans_sumk = self.effective_transformation_sumk
 
-        assert len(eff_trans_sumk) == len(new_gf_struct),\
+        assert len(self.gf_struct_solver) == len(new_gf_struct),\
             "new_gf_struct has the wrong length"
 
         new_gf_struct_transformed = copy.deepcopy(new_gf_struct)


### PR DESCRIPTION
In the case of `SK.n_corr_shells` != `SK.n_inequiv_shells` the BlockStructure-function `pick_gf_struct_sumk` was not working properly.

`pick_gf_struct_sumk` expected a list of length `n_corr_shells` (correct would be `n_inequiv_shells`), which it - after some transformations - gave to `pick_gf_struct_solver` to do the mapping. `pick_gf_struct_solver` didn't check the correct length of the input at all (which would have caught the error) and then just used the first `n_iequiv_shells` entries to do the mapping, leading to unexpected behaviour.
