### PR TITLE
BUGFIX: negative k vectors in QE nscf.out

### DIFF
--- a/python/triqs_dft_tools/converters/wannier90.py
+++ b/python/triqs_dft_tools/converters/wannier90.py
@@ -1006,7 +1006,7 @@ class Wannier90Converter(ConverterTools):
                 if line.strip() == 'End of band structure calculation':
                     break
 
-            assert 'k = ' in out_data[ct + 2], 'Cannot read occupations. Set verbosity = "high" in {}'.format(out_filename)
+            assert 'k =' in out_data[ct + 2], 'Cannot read occupations. Set verbosity = "high" in {}'.format(out_filename)
             out_data = out_data[ct+2:]
 
             # block size of eigenvalues + occupations per k-point


### PR DESCRIPTION
Removed redundant space in wannier90 converter to account for sitations of the type

k =-0.3333 0.0000 0.0000 ( 10719 PWs)   bands (ev):

which with 

`assert 'k = '` were being neglected