### PR TITLE
Use rotloc matrix in add_dc only when use_rotations is True (Issue #190)

### DIFF
--- a/python/triqs_dft_tools/sumk_dft.py
+++ b/python/triqs_dft_tools/sumk_dft.py
@@ -1801,8 +1801,12 @@ class SumkDFT(object):
         for icrsh in range(self.n_corr_shells):
             for bname, gf in sigma_minus_dc[icrsh]:
                 # Transform dc_imp to global coordinate system
-                dccont = numpy.dot(self.rot_mat[icrsh], numpy.dot(self.dc_imp[icrsh][
-                                   bname], self.rot_mat[icrsh].conjugate().transpose()))
+                if self.use_rotations:
+                    dccont = numpy.dot(self.rot_mat[icrsh], numpy.dot(self.dc_imp[icrsh][
+                                    bname], self.rot_mat[icrsh].conjugate().transpose()))
+                else:
+                    dccont = self.dc_imp[icrsh][bname]
+                    
                 sigma_minus_dc[icrsh][bname] -= dccont
 
         return sigma_minus_dc


### PR DESCRIPTION
This is a small fix for Issue #190, where in the (rare) case where one manually sets `use_rotations` to False the rotation was performed anyways in `add_dc()`. Now it's consistent with the behavior of e.g. `density_matrix()`