### PR TITLE
Modify gf_struct to be in line with triqs/3.1.x

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -23,11 +23,11 @@ DFTTools Version 3.1.0 is a release that
 * bugfix: This fix makes the function find_rot_mat() safer to use in case there are errors in finding the correct mapping. The converter will now abort if the agreement in mapping is below a user-definable threshold.
 
 ### Change in gf_struct
-* In line with TRIQS 3.1.x, the form of the Green's function's structure (`gf_struct`) has been modified
+* In line with TRIQS 3.1.x, the form of the Green's function's structure (`gf_struct`) has been modified (see [triqs changelog](https://triqs.github.io/triqs/latest/ChangeLog.html#change-in-gf-struct-objects) for more information)
 * Instead of `gf_struct = [("up", [0, 1]), ("down", [0, 1])]`, the new convention uses `gf_struct = [("up", 2), ("down", 2)]`
 * This modifies the form of `gf_struct_solver` (and `sumk`) in `block_structure` and `SumkDFT` as well.
 * Backwards-compatibility with old, stored `block_structure` objects is given, however a warning is issued.
-* A helper-function `block_structure.gf_struct_flatten(...)` is provided to manually bring `gf_struct`s to the new form.
+* A helper-function `triqs.gf.block_gf.fix_gf_struct_type(gf_struct_old)` is provided in triqs to manually bring `gf_struct`s to the new form.
 
 ### Documentation
 * change to read the docs sphinx theme

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -22,6 +22,13 @@ DFTTools Version 3.1.0 is a release that
 * update documentation of W90 Converter
 * bugfix: This fix makes the function find_rot_mat() safer to use in case there are errors in finding the correct mapping. The converter will now abort if the agreement in mapping is below a user-definable threshold.
 
+### Change in gf_struct
+* In line with TRIQS 3.1.x, the form of the Green's function's structure (`gf_struct`) has been modified
+* Instead of `gf_struct = [("up", [0, 1]), ("down", [0, 1])]`, the new convention uses `gf_struct = [("up", 2), ("down", 2)]`
+* This modifies the form of `gf_struct_solver` (and `sumk`) in `block_structure` and `SumkDFT` as well.
+* Backwards-compatibility with old, stored `block_structure` objects is given, however a warning is issued.
+* A helper-function `block_structure.gf_struct_flatten(...)` is provided to manually bring `gf_struct`s to the new form.
+
 ### Documentation
 * change to read the docs sphinx theme
 * clean up various doc files

--- a/doc/tutorials/images_scripts/nio_csc.py
+++ b/doc/tutorials/images_scripts/nio_csc.py
@@ -6,7 +6,6 @@ from triqs.gf import *
 import sys, triqs.version as triqs_version
 from triqs_dft_tools.sumk_dft import *
 from triqs_dft_tools.sumk_dft_tools import *
-from triqs_dft_tools.block_structure import gf_struct_flatten
 from triqs.operators.util.hamiltonians import *
 from triqs.operators.util.U_matrix import *
 from triqs_cthyb import *
@@ -21,14 +20,14 @@ warnings.filterwarnings("ignore", category=FutureWarning)
 
 def dmft_cycle():
     filename = 'nio'
-    
+
     Converter = VaspConverter(filename=filename)
     Converter.convert_dft_input()
-    
+
     SK = SumkDFT(hdf_file = filename+'.h5', use_dft_blocks = False)
-    
-    beta = 5.0 
-     
+
+    beta = 5.0
+
     Sigma = SK.block_structure.create_gf(beta=beta)
     SK.put_Sigma([Sigma])
     G = SK.extract_G_loc()
@@ -40,38 +39,38 @@ def dmft_cycle():
             mpi.report('block {0:d} consists of orbitals:'.format(iblock))
             for keys in list(SK.deg_shells[i_sh][iblock].keys()):
                 mpi.report('  '+keys)
-    
+
     # Setup CTQMC Solver
-    
+
     n_orb = SK.corr_shells[0]['dim']
     spin_names = ['up','down']
     orb_names = [i for i in range(0,n_orb)]
-    
+
     #gf_struct = set_operator_structure(spin_names, orb_names, orb_hyb)
-    gf_struct = SK.gf_struct_solver[0]
+    gf_struct = SK.gf_struct_solver_list[0]
     mpi.report('Sumk to Solver: %s'%SK.sumk_to_solver)
     mpi.report('GF struct sumk: %s'%SK.gf_struct_sumk)
     mpi.report('GF struct solver: %s'%SK.gf_struct_solver)
-    
+
     S = Solver(beta=beta, gf_struct=gf_struct)
-    
+
     # Construct the Hamiltonian and save it in Hamiltonian_store.txt
-    H = Operator() 
+    H = Operator()
     U = 8.0
     J = 1.0
-    
-    
+
+
     U_sph = U_matrix(l=2, U_int=U, J_hund=J)
     U_cubic = transform_U_matrix(U_sph, spherical_to_cubic(l=2, convention=''))
     Umat, Upmat = reduce_4index_to_2index(U_cubic)
-    
+
     H = h_int_density(spin_names, orb_names, map_operator_structure=SK.sumk_to_solver[0], U=Umat, Uprime=Upmat)
-    
+
     # Print some information on the master node
     mpi.report('Greens function structure is: %s '%gf_struct)
     mpi.report('U Matrix set to:\n%s'%Umat)
     mpi.report('Up Matrix set to:\n%s'%Upmat)
-    
+
     # Parameters for the CTQMC Solver
     p = {}
     p["max_time"] = -1
@@ -84,14 +83,14 @@ def dmft_cycle():
     p["fit_min_n"] = 30
     p["fit_max_n"] = 50
     p["perform_tail_fit"] = True
-    
+
     # Double Counting: 0 FLL, 1 Held, 2 AMF
     DC_type = 0
     DC_value = 59.0
-    
+
     # Prepare hdf file and and check for previous iterations
     n_iterations = 1
-    
+
     iteration_offset = 0
     if mpi.is_master_node():
         ar = HDFArchive(filename+'.h5','a')
@@ -119,33 +118,33 @@ def dmft_cycle():
     SK.dc_imp = mpi.bcast(SK.dc_imp)
     SK.dc_energ = mpi.bcast(SK.dc_energ)
     SK.chemical_potential = mpi.bcast(SK.chemical_potential)
-    
+
     # Calc the first G0
     SK.symm_deg_gf(S.Sigma_iw, ish=0)
     SK.put_Sigma(Sigma_imp = [S.Sigma_iw])
     SK.calc_mu(precision=0.01)
     S.G_iw << SK.extract_G_loc()[0]
     SK.symm_deg_gf(S.G_iw, ish=0)
-    
+
     #Init the DC term and the self-energy if no previous iteration was found
     if iteration_offset == 0:
         dm = S.G_iw.density()
         SK.calc_dc(dm, U_interact=U, J_hund=J, orb=0, use_dc_formula=DC_type,use_dc_value=DC_value)
         S.Sigma_iw << SK.dc_imp[0]['up'][0,0]
-    
+
     mpi.report('%s DMFT cycles requested. Starting with iteration %s.'%(n_iterations,iteration_offset))
-    
-    
-    
+
+
+
     # The infamous DMFT self consistency cycle
     for it in range(iteration_offset, iteration_offset + n_iterations):
         mpi.report('Doing iteration: %s'%it)
-        
+
         # Get G0
         S.G0_iw << inverse(S.Sigma_iw + inverse(S.G_iw))
         # Solve the impurity problem
         S.solve(h_int = H, **p)
-        if mpi.is_master_node(): 
+        if mpi.is_master_node():
             ar['DMFT_input']['Iterations']['solver_dict_it'+str(it)] = p
             ar['DMFT_results']['Iterations']['Gimp_it'+str(it)] = S.G_iw
             ar['DMFT_results']['Iterations']['Gtau_it'+str(it)] = S.G_tau
@@ -158,13 +157,13 @@ def dmft_cycle():
         SK.put_Sigma(Sigma_imp=[S.Sigma_iw])
         SK.calc_mu(precision=0.01)
         S.G_iw << SK.extract_G_loc()[0]
-        
+
         # print densities
         for sig,gf in S.G_iw:
             mpi.report("Orbital %s density: %.6f"%(sig,dm[sig][0,0]))
         mpi.report('Total charge of Gloc : %.6f'%S.G_iw.total_density())
-    
-        if mpi.is_master_node(): 
+
+        if mpi.is_master_node():
             ar['DMFT_results']['iteration_count'] = it
             ar['DMFT_results']['Iterations']['Sigma_it'+str(it)] = S.Sigma_iw
             ar['DMFT_results']['Iterations']['Gloc_it'+str(it)] = S.G_iw
@@ -172,31 +171,31 @@ def dmft_cycle():
             ar['DMFT_results']['Iterations']['dc_imp'+str(it)] = SK.dc_imp
             ar['DMFT_results']['Iterations']['dc_energ'+str(it)] = SK.dc_energ
             ar['DMFT_results']['Iterations']['chemical_potential'+str(it)] = SK.chemical_potential
-    
-    
-    
-    
+
+
+
+
     if mpi.is_master_node():
         print('calculating mu...')
     SK.chemical_potential = SK.calc_mu( precision = 0.000001 )
-    
+
     if mpi.is_master_node():
         print('calculating GAMMA')
     SK.calc_density_correction(dm_type='vasp')
-    
+
     if mpi.is_master_node():
         print('calculating energy corrections')
-    
+
     correnerg = 0.5 * (S.G_iw * S.Sigma_iw).total_density()
-    
+
     dm = S.G_iw.density() # compute the density matrix of the impurity problem
     SK.calc_dc(dm, U_interact=U, J_hund=J, orb=0, use_dc_formula=DC_type,use_dc_value=DC_value)
     dc_energ = SK.dc_energ[0]
-    
-    if mpi.is_master_node(): 
+
+    if mpi.is_master_node():
         ar['DMFT_results']['Iterations']['corr_energy_it'+str(it)] = correnerg
         ar['DMFT_results']['Iterations']['dc_energy_it'+str(it)] = dc_energ
-    
+
     if mpi.is_master_node(): del ar
-        
+
     return correnerg, dc_energ

--- a/python/triqs_dft_tools/block_structure.py
+++ b/python/triqs_dft_tools/block_structure.py
@@ -122,6 +122,7 @@ class BlockStructure(object):
                  transformation=None):
         
         # Ensure backwards-compatibility with pre-3.1.x gf_structs
+        # on second thought: would be better with gf_struct_flatten i guess... #TODO!
         if gf_struct_sumk != None:
             for gf_struct in gf_struct_sumk:
                 for i, block in enumerate(gf_struct):

--- a/python/triqs_dft_tools/block_structure.py
+++ b/python/triqs_dft_tools/block_structure.py
@@ -280,13 +280,9 @@ class BlockStructure(object):
 
                 # zero out all the lines of the transformation that are
                 # not included in gf_struct_solver
-                #TODO CHECK THIS!
                 for iorb in range(self.gf_struct_sumk_dict[icrsh][block]):
                     if self.sumk_to_solver[ish][(block, iorb)][0] is None:
                         trans[icrsh][block][iorb, :] = 0.0
-                # for iorb, norb in enumerate(self.gf_struct_sumk_dict[icrsh][block]):
-                #     if self.sumk_to_solver[ish][(block, norb)][0] is None:
-                #         trans[icrsh][block][iorb, :] = 0.0
         return trans
 
     @property
@@ -560,7 +556,6 @@ class BlockStructure(object):
                     gfs[icrsh][ind_sol[0]].append(ind_sol[1])
         self.pick_gf_struct_solver(gfs)
 
-    # TODO!
     def map_gf_struct_solver(self, mapping):
         r""" Map the Green function structure from one struct to another.
 
@@ -611,6 +606,11 @@ class BlockStructure(object):
             for k in list(self.sumk_to_solver[ish].keys()):
                 if not k in su2so:
                     su2so[k] = (None, None)
+                    
+            for new_block in gf_struct:
+                assert all(np.sort(gf_struct[new_block]) == list(range(len(gf_struct[new_block])))) ,\
+                    "New gf_struct does not have valid 0-based indices!"
+                gf_struct[new_block] = len(gf_struct[new_block])
 
             self.adapt_deg_shells(gf_struct, ish)
 

--- a/python/triqs_dft_tools/block_structure.py
+++ b/python/triqs_dft_tools/block_structure.py
@@ -120,7 +120,7 @@ class BlockStructure(object):
                  deg_shells=None,
                  corr_to_inequiv = None,
                  transformation=None):
-        
+
         # Ensure backwards-compatibility with pre-3.1.x gf_structs
         show_gf_struct_warning = False
         if gf_struct_sumk != None:
@@ -625,7 +625,7 @@ class BlockStructure(object):
             for k in list(self.sumk_to_solver[ish].keys()):
                 if not k in su2so:
                     su2so[k] = (None, None)
-                    
+
             for new_block in gf_struct:
                 assert all(np.sort(gf_struct[new_block]) == list(range(len(gf_struct[new_block])))) ,\
                     "New gf_struct does not have valid 0-based indices!"
@@ -1189,46 +1189,6 @@ class BlockStructure(object):
         s += "transformation\n"
         s += str(self.transformation)
         return s
-
-def gf_struct_flatten(gf_struct):
-    '''
-    flattens gf_struct objecti
-
-    input gf_struct can looks like this:
-
-    [('up', [0, 1, 2]), ('down', [0, 1, 2])]
-
-    and will be returned as
-
-    [('up', 3), ('down', 3)]
-
-    Same for dict but replacing the values. This is for compatibility with the upcoming triqs releases.
-
-    Parameters
-    ----------
-    gf_struct: list of tuple or dict representing the Gf structure
-    __Returns:__
-    gf_struct_flat: flattens the values of the dict or the tuple representing the Gf indices by replacing them with the len of the list of indices
-
-    '''
-
-    if isinstance(gf_struct, list):
-        # create a copy of the original list
-        gf_struct_flat = gf_struct.copy()
-        for idx, block in enumerate(gf_struct_flat):
-            # exchange list of indices with length of list
-            gf_struct_flat[idx] = (block[0], len(block[1]))
-    elif isinstance(gf_struct, dict):
-        # create a copy of the original dict
-        gf_struct_flat = dict(gf_struct)
-        for key, value in gf_struct_flat.items():
-            # exchange list of indices with length of list
-            gf_struct_flat[key] = len(value)
-    else:
-        raise Exception('gf_struct input needs to be list or dict')
-
-
-    return gf_struct_flat
 
 from h5.formats import register_class
 register_class(BlockStructure)

--- a/python/triqs_dft_tools/block_structure.py
+++ b/python/triqs_dft_tools/block_structure.py
@@ -122,18 +122,22 @@ class BlockStructure(object):
                  transformation=None):
         
         # Ensure backwards-compatibility with pre-3.1.x gf_structs
-        # on second thought: would be better with gf_struct_flatten i guess... #TODO!
+        show_gf_struct_warning = False
         if gf_struct_sumk != None:
             for gf_struct in gf_struct_sumk:
                 for i, block in enumerate(gf_struct):
                     if isinstance(block[1], (list, np.ndarray)):
                         gf_struct[i] = (block[0], len(block[1]))
+                        show_gf_struct_warning = True
         if gf_struct_solver != None:
             for gf_struct in gf_struct_solver:
                 for block in gf_struct:
                     if isinstance(gf_struct[block], (list, np.ndarray)):
                         gf_struct[block] = len(gf_struct[block])
-        
+                        show_gf_struct_warning = True
+        if show_gf_struct_warning:
+            warn('Old (pre 3.1.x) form of gf_struct provided! The structure will be updated to the new convention!')
+
         self.gf_struct_sumk = gf_struct_sumk
         self.gf_struct_solver = gf_struct_solver
 

--- a/python/triqs_dft_tools/block_structure.py
+++ b/python/triqs_dft_tools/block_structure.py
@@ -120,8 +120,22 @@ class BlockStructure(object):
                  deg_shells=None,
                  corr_to_inequiv = None,
                  transformation=None):
+        
+        # Ensure backwards-compatibility with pre-3.1.x gf_structs
+        if gf_struct_sumk != None:
+            for gf_struct in gf_struct_sumk:
+                for i, block in enumerate(gf_struct):
+                    if isinstance(block[1], (list, np.ndarray)):
+                        gf_struct[i] = (block[0], len(block[1]))
+        if gf_struct_solver != None:
+            for gf_struct in gf_struct_solver:
+                for block in gf_struct:
+                    if isinstance(gf_struct[block], (list, np.ndarray)):
+                        gf_struct[block] = len(gf_struct[block])
+        
         self.gf_struct_sumk = gf_struct_sumk
         self.gf_struct_solver = gf_struct_solver
+
         self.solver_to_sumk = solver_to_sumk
         self.sumk_to_solver = sumk_to_solver
         self.solver_to_sumk_block = solver_to_sumk_block

--- a/python/triqs_dft_tools/block_structure.py
+++ b/python/triqs_dft_tools/block_structure.py
@@ -136,13 +136,13 @@ class BlockStructure(object):
         This is returned as a
         list (for each shell)
         of lists (for each block)
-        of tuples (block_name, block_indices).
+        of tuples (block_name, block_dimension).
 
         That is,
         ``gf_struct_solver_list[ish][b][0]``
         is the name of the block number ``b`` of shell ``ish``, and
         ``gf_struct_solver_list[ish][b][1]``
-        is a list of its indices.
+        is the dimension of the block ``b``.
 
         The list for each shell is sorted alphabetically by block name.
         """
@@ -159,13 +159,13 @@ class BlockStructure(object):
         This is returned as a
         list (for each shell)
         of lists (for each block)
-        of tuples (block_name, block_indices)
+        of tuples (block_name, block_dimension)
 
         That is,
         ``gf_struct_sumk_list[ish][b][0]``
         is the name of the block number ``b`` of shell ``ish``, and
         ``gf_struct_sumk_list[ish][b][1]``
-        is a list of its indices.
+        is the dimension of the block ``b``.
         """
         return self.gf_struct_sumk
 
@@ -179,7 +179,7 @@ class BlockStructure(object):
 
         That is,
         ``gf_struct_solver_dict[ish][bname]``
-        is a list of the indices of block ``bname`` of shell ``ish``.
+        is the dimension of block ``bname`` of shell ``ish``.
         """
         return self.gf_struct_solver
 
@@ -193,7 +193,7 @@ class BlockStructure(object):
 
         That is,
         ``gf_struct_sumk_dict[ish][bname]``
-        is a list of the indices of block ``bname`` of shell ``ish``.
+        is the dimension of block ``bname`` of shell ``ish``.
         """
         if self.gf_struct_sumk is None:
             return None

--- a/python/triqs_dft_tools/sumk_dft.py
+++ b/python/triqs_dft_tools/sumk_dft.py
@@ -1119,7 +1119,7 @@ class SumkDFT(object):
 
         # transform G to the new structure
         full_structure = BlockStructure.full_structure(
-            [{sp:list(range(self.corr_shells[self.inequiv_to_corr[ish]]['dim']))
+            [{sp:self.corr_shells[self.inequiv_to_corr[ish]]['dim']
                 for sp in self.spin_block_names[self.corr_shells[self.inequiv_to_corr[ish]]['SO']]}
                 for ish in range(self.n_inequiv_shells)],self.corr_to_inequiv)
         G_transformed = [

--- a/python/triqs_dft_tools/sumk_dft_tools.py
+++ b/python/triqs_dft_tools/sumk_dft_tools.py
@@ -97,8 +97,8 @@ class SumkDFTTools(SumkDFT):
         G_loc = []
         for icrsh in range(self.n_corr_shells):
             spn = self.spin_block_names[self.corr_shells[icrsh]['SO']]
-            glist = [GfReFreq(indices=inner, window=(om_min, om_max), n_points=n_om)
-                     for block, inner in self.gf_struct_sumk[icrsh]]
+            glist = [GfReFreq(target_shape=(block_dim, block_dim), window=(om_min, om_max), n_points=n_om)
+                     for block, block_dim in self.gf_struct_sumk[icrsh]]
             G_loc.append(
                 BlockGf(name_list=spn, block_list=glist, make_copies=False))
         for icrsh in range(self.n_corr_shells):
@@ -236,8 +236,8 @@ class SumkDFTTools(SumkDFT):
         n_local_orbs = self.proj_mat_csc.shape[2]
         gf_struct_parproj_all = [[(sp, list(range(n_local_orbs))) for sp in spn]]
 
-        glist_all = [GfReFreq(indices=inner, window=(om_min, om_max), n_points=n_om)
-                     for block, inner in gf_struct_parproj_all[0]]
+        glist_all = [GfReFreq(target_shape=(block_dim, block_dim), window=(om_min, om_max), n_points=n_om)
+                     for block, block_dim in gf_struct_parproj_all[0]]
         G_loc_all = BlockGf(name_list=spn, block_list=glist_all, make_copies=False)
 
         DOS = {sp: numpy.zeros([n_om], numpy.float_)
@@ -364,11 +364,11 @@ class SumkDFTTools(SumkDFT):
 
         G_loc = []
         spn = self.spin_block_names[self.SO]
-        gf_struct_parproj = [[(sp, list(range(self.shells[ish]['dim']))) for sp in spn]
+        gf_struct_parproj = [[(sp, self.shells[ish]['dim']) for sp in spn]
                              for ish in range(self.n_shells)]
         for ish in range(self.n_shells):
-            glist = [GfReFreq(indices=inner, window=(om_min, om_max), n_points=n_om)
-                     for block, inner in gf_struct_parproj[ish]]
+            glist = [GfReFreq(target_shape=(block_dim, block_dim), window=(om_min, om_max), n_points=n_om)
+                     for block, block_dim in gf_struct_parproj[ish]]
             G_loc.append(
                 BlockGf(name_list=spn, block_list=glist, make_copies=False))
         for ish in range(self.n_shells):
@@ -873,9 +873,9 @@ class SumkDFTTools(SumkDFT):
 
         if not ishell is None:
             gf_struct_parproj = [
-                (sp, list(range(self.shells[ishell]['dim']))) for sp in spn]
-            G_loc = BlockGf(name_block_generator=[(block, GfReFreq(indices=inner, mesh=self.Sigma_imp_w[0].mesh))
-                                                  for block, inner in gf_struct_parproj], make_copies=False)
+                (sp, self.shells[ishell]['dim']) for sp in spn]
+            G_loc = BlockGf(name_block_generator=[(block, GfReFreq(target_shape=(block_dim, block_dim), mesh=self.Sigma_imp_w[0].mesh))
+                                                  for block, block_dim in gf_struct_parproj], make_copies=False)
             G_loc.zero()
 
         ikarray = numpy.array(list(range(self.n_k)))
@@ -993,16 +993,16 @@ class SumkDFTTools(SumkDFT):
                                  for ish in range(self.n_shells)]
                                 for isp in range(len(spn))]
         # Set up G_loc
-        gf_struct_parproj = [[(sp, list(range(self.shells[ish]['dim']))) for sp in spn]
+        gf_struct_parproj = [[(sp, self.shells[ish]['dim']) for sp in spn]
                              for ish in range(self.n_shells)]
         if with_Sigma:
-            G_loc = [BlockGf(name_block_generator=[(block, GfImFreq(indices=inner, mesh=self.Sigma_imp_iw[0].mesh))
-                                                   for block, inner in gf_struct_parproj[ish]], make_copies=False)
+            G_loc = [BlockGf(name_block_generator=[(block, GfImFreq(target_shape=(block_dim, block_dim), mesh=self.Sigma_imp_iw[0].mesh))
+                                                   for block, block_dim in gf_struct_parproj[ish]], make_copies=False)
                      for ish in range(self.n_shells)]
             beta = self.Sigma_imp_iw[0].mesh.beta
         else:
-            G_loc = [BlockGf(name_block_generator=[(block, GfImFreq(indices=inner, beta=beta))
-                                                   for block, inner in gf_struct_parproj[ish]], make_copies=False)
+            G_loc = [BlockGf(name_block_generator=[(block, GfImFreq(target_shape=(block_dim, block_dim), beta=beta))
+                                                   for block, block_dim in gf_struct_parproj[ish]], make_copies=False)
                      for ish in range(self.n_shells)]
         for ish in range(self.n_shells):
             G_loc[ish].zero()
@@ -1227,8 +1227,8 @@ class SumkDFTTools(SumkDFT):
                 for icrsh in range(self.n_corr_shells):
                     Sigma_save = self.Sigma_imp_w[icrsh].copy()
                     spn = self.spin_block_names[self.corr_shells[icrsh]['SO']]
-                    glist = lambda: [GfReFreq(indices=inner, window=(self.omega[
-                                              0], self.omega[-1]), n_points=n_om) for block, inner in self.gf_struct_sumk[icrsh]]
+                    glist = lambda: [GfReFreq(target_shape=(block_dim, block_dim), window=(self.omega[
+                                              0], self.omega[-1]), n_points=n_om) for block, block_dim in self.gf_struct_sumk[icrsh]]
                     self.Sigma_imp_w[icrsh] = BlockGf(
                         name_list=spn, block_list=glist(), make_copies=False)
                     for i, g in self.Sigma_imp_w[icrsh]:

--- a/python/triqs_dft_tools/trans_basis.py
+++ b/python/triqs_dft_tools/trans_basis.py
@@ -150,14 +150,14 @@ class TransBasis:
 
         # build a full GF
         gfrotated = BlockGf(name_block_generator=[(block, GfImFreq(
-            indices=inner, mesh=gf_to_rot.mesh)) for block, inner in self.SK.gf_struct_sumk[0]], make_copies=False)
+            target_shape=(block_dim, block_dim), mesh=gf_to_rot.mesh)) for block, block_dim in self.SK.gf_struct_sumk[0]], make_copies=False)
 
         # transform the CTQMC blocks to the full matrix:
         # ish is the index of the inequivalent shell corresponding to icrsh
         ish = self.SK.corr_to_inequiv[0]
-        for block, inner in self.gf_struct_solver[ish].items():
-            for ind1 in inner:
-                for ind2 in inner:
+        for block, block_dim in self.gf_struct_solver[ish].items():
+            for ind1 in range(block_dim):
+                for ind2 in range(block_dim):
                     gfrotated[self.SK.solver_to_sumk_block[ish][block]][
                         ind1, ind2] << gf_to_rot[block][ind1, ind2]
 
@@ -168,9 +168,9 @@ class TransBasis:
 
         gfreturn = gf_to_rot.copy()
         # Put back into CTQMC basis:
-        for block, inner in self.gf_struct_solver[ish].items():
-            for ind1 in inner:
-                for ind2 in inner:
+        for block, block_dim in self.gf_struct_solver[ish].items():
+            for ind1 in range(block_dim):
+                for ind2 in range(block_dim):
                     gfreturn[block][ind1, ind2] << gfrotated[
                         self.SK.solver_to_sumk_block[0][block]][ind1, ind2]
 

--- a/test/python/analyse_block_structure_from_gf2.py
+++ b/test/python/analyse_block_structure_from_gf2.py
@@ -54,11 +54,11 @@ SK.symm_deg_gf(G_new_symm, 0)
 assert_block_gfs_are_close(G_new[0], G_new_symm)
 
 
-assert SK.gf_struct_sumk == [[('ud', [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])], [('ud', [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])]],\
+assert SK.gf_struct_sumk == [[('ud', 10)], [('ud', 10)]],\
     "wrong gf_struct_sumk"
 for i in range(5):
     assert 'ud_{}'.format(i) in SK.gf_struct_solver[0], "missing block"
-    assert SK.gf_struct_solver[0]['ud_{}'.format(i)] == list(range(2)), "wrong block size"
+    assert SK.gf_struct_solver[0]['ud_{}'.format(i)] == 2, "wrong block size"
 for i in range(10):
     assert SK.sumk_to_solver[0]['ud',i] == ('ud_{}'.format(i//2), i%2), "wrong mapping"
 
@@ -98,11 +98,11 @@ G_new_symm = G_new[0].copy()
 SK.symm_deg_gf(G_new_symm, 0)
 assert_block_gfs_are_close(G_new[0], G_new_symm)
 
-assert SK.gf_struct_sumk == [[('ud', [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])], [('ud', [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])]],\
+assert SK.gf_struct_sumk == [[('ud', 10)], [('ud', 10)]],\
     "wrong gf_struct_sumk"
 for i in range(5):
     assert 'ud_{}'.format(i) in SK.gf_struct_solver[0], "missing block"
-    assert SK.gf_struct_solver[0]['ud_{}'.format(i)] == list(range(2)), "wrong block size"
+    assert SK.gf_struct_solver[0]['ud_{}'.format(i)] == 2, "wrong block size"
 for i in range(10):
     assert SK.sumk_to_solver[0]['ud',i] == ('ud_{}'.format(i//2), i%2), "wrong mapping"
 

--- a/test/python/basis_transformation.py
+++ b/test/python/basis_transformation.py
@@ -1,3 +1,4 @@
+from tkinter import W
 from triqs.utility.comparison_tests import *
 from triqs_dft_tools.sumk_dft import *
 import numpy as np
@@ -92,7 +93,7 @@ BS.transformation = [{'up':np.array([[1,0,0],[0,1/np.sqrt(2),1/np.sqrt(2)],[0,1/
 H3 = BS.convert_operator(h_int_slater(spin_names=['up','down'], orb_names=[0,1,2], U_matrix=U3x3, off_diag=True))
 for op in H3:
     for c_op in op[0]:
-        assert(BS.gf_struct_solver_dict[0][c_op[1][0]][c_op[1][1]] is not None) # This crashes with a key error if the operator structure is not the solver structure
+        assert(BS.solver_to_sumk[0][(c_op[1][0], c_op[1][1])] is not None) # This crashes with a key error if the operator structure is not the solver structure
 
 U_trafod = transform_U_matrix(U3x3, BS.transformation[0]['up'].conjugate()) # The notorious .conjugate()
 H4 = h_int_slater(spin_names=['up','down'], orb_names=range(3), U_matrix=U_trafod, map_operator_structure=BS.sumk_to_solver[0])

--- a/test/python/basis_transformation.py
+++ b/test/python/basis_transformation.py
@@ -1,4 +1,3 @@
-from tkinter import W
 from triqs.utility.comparison_tests import *
 from triqs_dft_tools.sumk_dft import *
 import numpy as np

--- a/test/python/blockstructure.py
+++ b/test/python/blockstructure.py
@@ -3,7 +3,7 @@ from triqs.utility.h5diff import h5diff, compare, failures
 from triqs.gf import *
 from triqs.utility.comparison_tests import assert_block_gfs_are_close
 from scipy.linalg import expm
-from triqs_dft_tools.block_structure import BlockStructure, gf_struct_flatten
+from triqs_dft_tools.block_structure import BlockStructure
 import numpy as np
 
 

--- a/test/python/blockstructure.py
+++ b/test/python/blockstructure.py
@@ -174,11 +174,9 @@ cmp(m2,
 
 # check full_structure
 full = BlockStructure.full_structure(
-    [{'up_0': [0, 1], 'up_1': [0], 'down_1': [0], 'down_0': [0, 1]}], None)
+    [{'up_0': 2, 'up_1': 1, 'down_1': 1, 'down_0': 2}], None)
 
-print(original_bs.gf_struct_sumk[0])
-print(gf_struct_flatten(original_bs.gf_struct_sumk[0]))
-G_sumk = BlockGf(mesh=G1.mesh, gf_struct=gf_struct_flatten(original_bs.gf_struct_sumk[0]))
+G_sumk = BlockGf(mesh=G1.mesh, gf_struct=original_bs.gf_struct_sumk[0])
 for i in range(3):
     G_sumk['up'][i, i] << SemiCircular(1 if i < 2 else 2)
     G_sumk['down'][i, i] << SemiCircular(4 if i < 2 else 3)
@@ -204,13 +202,13 @@ G_bT = transformed_bs.convert_gf(G_T, None, space_from='sumk',
 assert_block_gfs_are_close(G1, G_bT)
 
 assert original_bs.gf_struct_sumk_list ==\
-    [[('up', [0, 1, 2]), ('down', [0, 1, 2])]]
+    [[('up', 3), ('down', 3)]]
 assert original_bs.gf_struct_solver_dict ==\
-    [{'up_0': [0, 1], 'up_1': [0], 'down_1': [0], 'down_0': [0, 1]}]
+    [{'up_0': 2, 'up_1': 1, 'down_1': 1, 'down_0': 2}]
 assert original_bs.gf_struct_sumk_dict ==\
-    [{'down': [0, 1, 2], 'up': [0, 1, 2]}]
+    [{'down': 3, 'up': 3}]
 assert original_bs.gf_struct_solver_list ==\
-    [[('down_0', [0, 1]), ('down_1', [0]), ('up_0', [0, 1]), ('up_1', [0])]]
+    [[('down_0', 2), ('down_1', 1), ('up_0', 2), ('up_1', 1)]]
 
 # check __eq__
 assert full == full, 'equality not correct (equal structures not equal)'


### PR DESCRIPTION
This should adapt `block_structure` and `SumkDFT` to the new gf_struct naming conventions (instead of `('block_name', [0,1,2,3])` now `('block_name', 4)`.

I've adapted the unit-tests and added a layer of backwards-compatibility (in the constructor of block_structure).

The unit-tests are all working, however I want to test this tomorrow with some real calculations. We should probably wait with merging until then.
I still need to add this to the changelog as well.

Best,
Hermann