### PR TITLE
Allow Wien2k Converter to leave out correlated shells while having orthonormalized projectors for these shells

### DIFF
--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -52,6 +52,13 @@ autosummary_imported_members=False
 project = 'TRIQS DFTTools'
 version = '@PROJECT_VERSION@'
 
+# this makes the current project version available as var in every rst file
+rst_epilog = """
+.. |PROJECT_VERSION| replace:: {version}
+""".format(
+version = version,
+)
+
 copyright = '2011-2021'
 
 mathjax_path = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=default"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,9 +4,9 @@
 DFTTools
 #########
 
-.. sidebar:: DFTTools 3.0.0
+.. sidebar:: DFTTools |PROJECT_VERSION|
 
-   This is the homepage of DFTTools v3.0.0.
+   This is the homepage of DFTTools |PROJECT_VERSION|
    For changes see the :ref:`changelog page <changelog>`.
       
       .. image:: _static/logo_github.png

--- a/packaging/TRIQS-dft_tools-3.1.0-foss-2021b.eb
+++ b/packaging/TRIQS-dft_tools-3.1.0-foss-2021b.eb
@@ -27,7 +27,7 @@ toolchainopts = {'pic': True, 'usempi': True}
 
 source_urls = ['https://github.com/TRIQS/dft_tools/releases/download/%(version)s/']
 sources = ['dft_tools-%(version)s.tar.gz']
-checksums = ['PUT HERE THE SHA256 OF THE RELEASE TARBALL']
+checksums = ['57b7d0fe5a96c5a42bb684c60ca8e136a33e1385bf6cd7e9d1371fa507dc2ec4']
 
 dependencies = [
     ('Python', '3.9.6'),


### PR DESCRIPTION
A potentially useful feature would be to allow the user to create orthonormalized projectors for more than just the correlated shells via the dmftproj program, then for the purposes of the DMFT calculation, leave out these extra correlated shells. This PR attempts to do this by providing the flag ``keep_corr_shells`` in the ``Wien2kConverter`` class.