### PR TITLE
transport k-mesh consistency check

### DIFF
--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -52,6 +52,13 @@ autosummary_imported_members=False
 project = 'TRIQS DFTTools'
 version = '@PROJECT_VERSION@'
 
+# this makes the current project version available as var in every rst file
+rst_epilog = """
+.. |PROJECT_VERSION| replace:: {version}
+""".format(
+version = version,
+)
+
 copyright = '2011-2021'
 
 mathjax_path = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=default"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,9 +4,9 @@
 DFTTools
 #########
 
-.. sidebar:: DFTTools 3.0.0
+.. sidebar:: DFTTools |PROJECT_VERSION|
 
-   This is the homepage of DFTTools v3.0.0.
+   This is the homepage of DFTTools |PROJECT_VERSION|
    For changes see the :ref:`changelog page <changelog>`.
       
       .. image:: _static/logo_github.png

--- a/packaging/TRIQS-dft_tools-3.1.0-foss-2021b.eb
+++ b/packaging/TRIQS-dft_tools-3.1.0-foss-2021b.eb
@@ -27,7 +27,7 @@ toolchainopts = {'pic': True, 'usempi': True}
 
 source_urls = ['https://github.com/TRIQS/dft_tools/releases/download/%(version)s/']
 sources = ['dft_tools-%(version)s.tar.gz']
-checksums = ['PUT HERE THE SHA256 OF THE RELEASE TARBALL']
+checksums = ['57b7d0fe5a96c5a42bb684c60ca8e136a33e1385bf6cd7e9d1371fa507dc2ec4']
 
 dependencies = [
     ('Python', '3.9.6'),

--- a/python/triqs_dft_tools/converters/wien2k.py
+++ b/python/triqs_dft_tools/converters/wien2k.py
@@ -696,6 +696,14 @@ class Wien2kConverter(ConverterTools):
                                         nu_i][nu_j][i].conjugate()
                 velocities_k[isp].append(velocity_xyz)
             band_window_optics.append(numpy.array(band_window_optics_isp))
+            # check the number of kpoints is correct
+            last_kpt = None
+            try:
+                last_kpt = next(R)
+            except:
+                pass
+            if last_kpt is not None: 
+                raise ValueError("The number of kpoints in case.pmat is larger than number of kpoints of Green's function. Please rerun dmftproj")
             R.close()  # Reading done!
 
         # Put data to HDF5 file


### PR DESCRIPTION
In the current transport converter, it uses the variable ``n_k`` which holds the number of k-points from the DFT+DMFT calculation to iterate over the ``case.pmat`` file. This causes a problem if the user created a denser k-mesh to compute the velocities on. This means that the ``convert_transport_input`` function is only partially reading ``case.pmat``. This results in velocities and Green's functions being defined on two **different** meshes (of the same length). Here, we provide a quick that the converter has actually reached the end of the ``case.pmat`` file.