### PR TITLE
transport kmesh check

### DIFF
--- a/python/triqs_dft_tools/converters/wien2k.py
+++ b/python/triqs_dft_tools/converters/wien2k.py
@@ -696,6 +696,14 @@ class Wien2kConverter(ConverterTools):
                                         nu_i][nu_j][i].conjugate()
                 velocities_k[isp].append(velocity_xyz)
             band_window_optics.append(numpy.array(band_window_optics_isp))
+            # check the number of kpoints is correct
+            last_kpt = None
+            try:
+                last_kpt = next(R)
+            except:
+                pass
+            if last_kpt is not None: 
+                raise ValueError("The number of kpoints in case.pmat is larger than number of kpoints of Green's function. Please rerun dmftproj")
             R.close()  # Reading done!
 
         # Put data to HDF5 file


### PR DESCRIPTION
In the current transport converter, it uses the variable ``n_k`` which holds the number of k-points from the DFT+DMFT calculation to iterate over the ``case.pmat`` file. This causes a problem if the user created a denser k-mesh to compute the velocities on. This means that the ``convert_transport_input`` function is only partially reading ``case.pmat``. This results in velocities and Green's functions being defined on two **different** meshes (of the same length). Here, we provide a quick that the converter has actually reached the end of the ``case.pmat`` file.