### PR TITLE
Fix for wannier converter: reordering of orbital/spin order only necessary for vasp 5

### DIFF
--- a/test/python/w90_convert_SrVO3_soc.py
+++ b/test/python/w90_convert_SrVO3_soc.py
@@ -33,7 +33,8 @@ subfolder = 'w90_convert/'
 # bloch_basis False
 seedname = subfolder+'SrVO3_soc'
 converter = Wannier90Converter(seedname=seedname, hdf_filename=seedname+'.out.h5',
-                               rot_mat_type='wannier', bloch_basis=False)
+                               rot_mat_type='wannier', bloch_basis=False,
+                               reorder_orbital_and_spin_vasp5=True)
 converter.convert_dft_input()
 
 if mpi.is_master_node():


### PR DESCRIPTION
Introduced parameter `reorder_orbital_and_spin_vasp5` to perform reordering. Defaults to false so that the default behavior is now correct for Quantum Espresso and Vasp 6. Solves issue #215.