### PR TITLE
Full charge self-consistency with ABINIT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,8 +108,9 @@ jobs:
       env:
         CC: ${{ matrix.cc }}
         CXX: ${{ matrix.cxx }}
+        TRIQS_BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
       run: |
-        git clone https://github.com/TRIQS/triqs --branch ${{ github.ref_name }}
+        git clone https://github.com/TRIQS/triqs --branch $TRIQS_BRANCH
         mkdir triqs/build && cd triqs/build
         cmake .. -DBuild_Tests=OFF -DCMAKE_INSTALL_PREFIX=$HOME/install
         make -j1 install VERBOSE=1

--- a/python/triqs_dft_tools/converters/wannier90.py
+++ b/python/triqs_dft_tools/converters/wannier90.py
@@ -144,6 +144,13 @@ class Wannier90Converter(ConverterTools):
             input_params = read_input_file(self.inp_file, self.fortran_to_replace)
         (kmesh_mode, kmesh_size, density_required, n_corr_shells,
          corr_shells, n_shells, shells, fermi_energy) = mpi.bcast(input_params)
+        mpi.report(" Extracted:")
+        mpi.report(" - kmesh_mode, kmesh_size: %s, %s" % (str(kmesh_mode), str(kmesh_size)))
+        mpi.report(" - density: %s" % str(density_required))
+        mpi.report(" - n_corr_shells: %s" % str(n_corr_shells))
+        mpi.report(" - corr_shells, n_shells, shells: %s, %s, %s" % (str(corr_shells), str(n_shells), str(shells)))
+        mpi.report(" - fermi_energy: %s" % str(fermi_energy))
+        mpi.report()
         if density_required is None and not self.bloch_basis:
             raise ValueError('Required density necessary if not in bloch basis')
 

--- a/python/triqs_dft_tools/converters/wannier90.py
+++ b/python/triqs_dft_tools/converters/wannier90.py
@@ -346,7 +346,6 @@ class Wannier90Converter(ConverterTools):
                     archive[self.misc_subgrp]['band_window'] = band_window+1 # Change to 1-based index
                     archive[self.misc_subgrp]['kpts_cart'] = np.dot(kpts, kpt_basis.T)
         mpi.barrier()
-        mpi.report("Saving done.\n")
 
         # Makes Fermi energy a class variable for testing
         self.fermi_energy = fermi_energy

--- a/python/triqs_dft_tools/sumk_dft.py
+++ b/python/triqs_dft_tools/sumk_dft.py
@@ -2387,8 +2387,8 @@ class SumkDFT(object):
                 ib2 = band_window[0][ik, 1]
                 for inu in range(self.n_orbitals[ik, 0]):
                     for imu in range(self.n_orbitals[ik, 0]):
-                        valre = (deltaN['up'][ik][inu, imu].real + deltaN['down'][ik][inu, imu].real)
-                        valim = (deltaN['up'][ik][inu, imu].imag + deltaN['down'][ik][inu, imu].imag)
+                        valre = (deltaN['up'][ik][inu, imu].real + deltaN['down'][ik][inu, imu].real) / 2.0
+                        valim = (deltaN['up'][ik][inu, imu].imag + deltaN['down'][ik][inu, imu].imag) / 2.0
                         # write into delta_N
                         delta_N[ik, inu, imu] = valre + 1j*valim
             if mpi.is_master_node():


### PR DESCRIPTION
This PR allows for charge self-consistent calculations with ABINIT. With ABINIT, one perform the Wannier90 calculation and print the DFT occupations in a file "w90_seed.abinit". Those are read by DFTTools. After performing the DMFT loop, the change in the occupations in the band basis are written in the file "w90_seed.delta_N", which is read by ABINIT.

I also corrected a few typos and changed slightly the outputted words. Feel free to remove that.