### PR TITLE
save H(R) from w90 to dft_input

### DIFF
--- a/python/triqs_dft_tools/converters/wannier90.py
+++ b/python/triqs_dft_tools/converters/wannier90.py
@@ -320,7 +320,7 @@ class Wannier90Converter(ConverterTools):
                 # created. If it exists, the data is overwritten!
                 things_to_save = ['energy_unit', 'n_k', 'k_dep_projection', 'SP', 'SO', 'charge_below', 'density_required',
                               'symm_op', 'n_shells', 'shells', 'n_corr_shells', 'corr_shells', 'use_rotations', 'rot_mat',
-                              'rot_mat_time_inv', 'n_reps', 'dim_reps', 'T', 'n_orbitals', 'proj_mat', 'bz_weights', 'hopping',
+                              'rot_mat_time_inv', 'n_reps', 'dim_reps', 'T', 'n_orbitals', 'proj_mat', 'bz_weights', 'hopping', 'wannier_hr',
                               'n_inequiv_shells', 'corr_to_inequiv', 'inequiv_to_corr', 'kpt_weights', 'kpts', 'dft_code']
                 if wan_centres is not None:
                     things_to_save.append('wan_centres')


### PR DESCRIPTION
I've added ``wannier_hr`` to be saved in ``dft_input``. This amounts to adding this as an entry in ``things_to_save``. The H(R) object is relatively small to save and having access to it without needing the original ``seedname_hr.dat`` will be useful for future TRIQS applications.