### PR TITLE
raise `ValueError` if dichotomy fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 compile_commands.json
 doc/_autosummary
 doc/cpp2rst_generated
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class

--- a/python/triqs_dft_tools/sumk_dft.py
+++ b/python/triqs_dft_tools/sumk_dft.py
@@ -2073,11 +2073,27 @@ class SumkDFT(object):
         # check for lowercase matching for the method variable
         if method.lower() == "dichotomy":
             mpi.report("\nsumk calc_mu: Using dichtomy adjustment to find chemical potential\n")
-            self.chemical_potential = dichotomy.dichotomy(function=F_bisection,
-                                                          x_init=self.chemical_potential, y_value=density,
-                                                          precision_on_y=precision, delta_x=delta, max_loops=max_loops,
-                                                          x_name="Chemical Potential", y_name="Total Density",
-                                                          verbosity=3)[0]
+            result = dichotomy.dichotomy(function=F_bisection,
+                                x_init=self.chemical_potential,
+                                y_value=density,
+                                precision_on_y=precision,
+                                delta_x=delta,
+                                max_loops=max_loops,
+                                x_name="Chemical Potential",
+                                y_name="Total Density",
+                                verbosity=3)
+            if result[0] is None:
+                raise ValueError(
+                    f"\nsumk calc_mu: Failed to find chemical potential using dichotomy method.\n"
+                    f"  Target total density: {density}\n"
+                    f"  Starting guess for chemical potential: {self.chemical_potential}\n"
+                    f"  Step size (delta): {delta}, Precision required: {precision}\n"
+                    f"  Maximum iterations allowed: {max_loops}\n"
+                    f"  The method could not converge: no value of mu found such that |F(mu) - {density}| < {precision}.\n"
+                    f"  Suggestion:\n"
+                    f"    Adjust the initial guess or increase delta."
+                )
+            self.chemical_potential = result[0]
         elif method.lower() == "newton":
             mpi.report("\nsumk calc_mu: Using Newton method to find chemical potential\n")
             self.chemical_potential = newton(func=F_optimize,


### PR DESCRIPTION
Address this issue from `solid_dmft`
[solid_dmft #100](https://github.com/TRIQS/solid_dmft/issues/100)
`dochotomy` can fail sometime and will return `None`, but the result will be sent to `chemical_potential` which causes downstream errors.
Here, we raise an exception and let the user know how it might have failed.